### PR TITLE
feat: add Custom model option to BYOK settings

### DIFF
--- a/src/features/ai/services/ai-client-config.ts
+++ b/src/features/ai/services/ai-client-config.ts
@@ -1,5 +1,6 @@
 import {
 	BYOK_MODELS,
+	CUSTOM_MODEL_ID,
 	DEFAULT_BYOK_MODEL,
 	LITELLM_URL,
 } from "@shared/constants";
@@ -36,9 +37,13 @@ export function resolveAIClientConfig(
 	}
 
 	if (settings.openRouterApiKey) {
+		const model =
+			settings.aiModel === CUSTOM_MODEL_ID
+				? settings.customAiModel || DEFAULT_BYOK_MODEL
+				: settings.aiModel || DEFAULT_BYOK_MODEL;
 		return {
 			apiKey: settings.openRouterApiKey,
-			model: settings.aiModel || DEFAULT_BYOK_MODEL,
+			model,
 			baseUrl: OPENROUTER_URL,
 			isPro: false,
 			temperature: resolveByokTemperature(settings),

--- a/src/features/settings/tabs/AITab.tsx
+++ b/src/features/settings/tabs/AITab.tsx
@@ -1,6 +1,6 @@
 import { GENERATION_LANGUAGES } from "@features/ai/prompts/default-prompts";
 import { useSettings } from "@features/settings/hooks/useSettings";
-import { BYOK_MODELS, TRUERECALL_WEB_URL } from "@shared/constants";
+import { BYOK_MODELS, CUSTOM_MODEL_ID, TRUERECALL_WEB_URL } from "@shared/constants";
 import {
 	Clickable,
 	FormCard,
@@ -15,10 +15,13 @@ import {
 import { requestUrl } from "obsidian";
 import { useEffect, useState } from "preact/hooks";
 
-const MODEL_OPTIONS = BYOK_MODELS.map((m) => ({
-	value: m.id,
-	label: `${m.name} (${m.provider})${m.recommended ? " — Recommended" : ""}`,
-}));
+const MODEL_OPTIONS = [
+	...BYOK_MODELS.map((m) => ({
+		value: m.id,
+		label: `${m.name} (${m.provider})${m.recommended ? " — Recommended" : ""}`,
+	})),
+	{ value: CUSTOM_MODEL_ID, label: "Custom..." },
+];
 
 function getModelDefault(modelId: string): number {
 	return BYOK_MODELS.find((m) => m.id === modelId)?.defaultTemperature ?? 0.7;
@@ -153,6 +156,19 @@ export function AITab() {
 						options={MODEL_OPTIONS}
 					/>
 				</FormField>
+				{currentModel === CUSTOM_MODEL_ID && (
+					<FormField
+						name="Custom Model ID"
+						description="Enter any OpenRouter-compatible model ID."
+					>
+						<TextInput
+							value={settings.customAiModel ?? ""}
+							onChange={(v) => save({ customAiModel: v })}
+							placeholder="e.g. openai/gpt-4o-mini"
+							class="ep:w-[300px]"
+						/>
+					</FormField>
+				)}
 
 				<FormField
 					name="Temperature"

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -59,6 +59,8 @@ export const BYOK_MODELS: ByokModelConfig[] = [
 	},
 ];
 
+export const CUSTOM_MODEL_ID = "__custom__";
+
 export const DEFAULT_BYOK_MODEL = "google/gemini-2.5-flash";
 
 export const DEFAULT_FSRS_PRESET: FSRSPreset = {

--- a/src/shared/types/settings.types.ts
+++ b/src/shared/types/settings.types.ts
@@ -142,6 +142,8 @@ export interface TrueRecallSettings {
 	openRouterApiKey: string;
 	/** Selected BYOK model ID (OpenRouter) */
 	aiModel: string;
+	/** Custom OpenRouter model ID — used when aiModel is __custom__ */
+	customAiModel?: string;
 	/** Custom temperature override — when undefined, uses model's default */
 	aiTemperature?: number;
 

--- a/src/shared/validation/schemas/settings.schema.ts
+++ b/src/shared/validation/schemas/settings.schema.ts
@@ -11,6 +11,7 @@ export const SettingsSchema = z.object({
 	proKey: z.string().optional(),
 	openRouterApiKey: z.string(),
 	aiModel: AIModelSchema,
+	customAiModel: z.string().optional(),
 	aiTier: AITierSchema,
 	autoSyncToAnki: z.boolean().default(false),
 	selectionToolbarEnabled: z.boolean().default(true),


### PR DESCRIPTION
Allow users to enter any OpenRouter model ID via a "Custom..." dropdown option that reveals a text input.

## Summary

Adds a "Custom..." option to the BYOK model dropdown in AI settings. When selected, a text input appears where users can type any OpenRouter-compatible model ID (e.g. `openai/gpt-4o-mini`). The custom model ID is stored in a new `customAiModel` settings field and resolved at API-call time by `resolveAIClientConfig`.

## Related issue

Closes #15

## How to test

1. Open Settings → AI tab
2. Enter an OpenRouter API key if not already set
3. Open the Model dropdown — verify "Custom..." appears at the bottom
4. Select "Custom..." — a text input should appear below the dropdown
5. Enter a model ID (e.g. `openai/gpt-4o-mini`) and verify it persists after closing/reopening settings
6. Select a preset model — verify the preset model is saved
7. Run `bun run build` — should pass with no errors

## Checklist

- [x] `bun run build` passes
- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [x] I have read and agree to the [contribution guidelines](../CONTRIBUTING.md)