### PR TITLE
fix(deps): pin typescript to ^5.8.3 to unblock Obsidian plugin review

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"sql.js": "^1.14.1",
 		"tailwindcss": "^4.1.18",
 		"tslib": "2.4.0",
-		"typescript": "^6.0.3",
+		"typescript": "^5.8.3",
 		"vitest": "^1.6.1"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary

- The bump to `typescript@^6.0.3` in 5e5fb801 was not propagated to `bun.lock` (still pinned to `5.8.3`), so `bun install --frozen-lockfile` fails on a clean clone.
- This is what the Obsidian Review Bot is hitting on PR [obsidianmd/obsidian-releases#11505](https://github.com/obsidianmd/obsidian-releases/pull/11505): repeated `error: lockfile had changes, but lockfile is frozen`.
- TypeScript 6 also breaks the build because `tsconfig.json` still uses `baseUrl`, deprecated in TS 6.0 (`error TS5101`).
- Reverting to `^5.8.3` (the version that actually shipped in tag `1.7.0`) restores lockfile parity and keeps `bun run build` green. A real TS 6 migration can be done deliberately later.

## Test plan

- [x] `bun install --frozen-lockfile` succeeds locally
- [x] `bun run build` succeeds locally (tsc + esbuild production)
- [ ] Obsidian Review Bot stops failing dependency install on the next re-check