### PR TITLE
release: v1.9.2 — switch LICENSE to PolyForm Strict 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.9.2 (2026-05-19)
+
+### Improvements
+
+- **License switched to PolyForm Strict 1.0.0** — replaced the custom source-available license with the canonical [PolyForm Strict 1.0.0](https://polyformproject.org/licenses/strict/1.0.0/) text so GitHub's license detector can recognize the repository. The restrictions are equivalent (noncommercial use only, no redistribution, no modifications, no competing products). Commercial licensing remains available — see the `## License` section in the README.
+
 ## 1.9.1 (2026-05-19)
 
 ### Bug Fixes

--- a/LICENSE
+++ b/LICENSE
@@ -1,76 +1,63 @@
-SPDX-License-Identifier: LicenseRef-True-Recall-Source-Available-1.0
+Copyright (c) 2026 Łukasz Piera
 
-True Recall Source-Available License 1.0
+SPDX-License-Identifier: PolyForm-Strict-1.0.0
 
-Copyright (c) 2026 Łukasz Piera. All rights reserved.
+# PolyForm Strict License 1.0.0
 
-DEFINITIONS
+<https://polyformproject.org/licenses/strict/1.0.0>
 
-"Licensed Work" means the True Recall software and all associated source code,
-documentation, and assets made available under this License.
+## Acceptance
 
-"Licensor" means Łukasz Piera, the copyright holder of the Licensed Work.
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
 
-"You" means any individual or legal entity exercising rights under this License.
+## Copyright License
 
-"Competing Product" means any software product or service that provides
-spaced-repetition flashcard functionality within the Obsidian application or
-as a standalone product that competes directly with the Licensed Work.
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose, other than distributing the software or making changes or new works based on the software.
 
-"Commercial Use" means any use of the Licensed Work intended for or directed
-toward commercial advantage or monetary compensation.
+## Patent License
 
-GRANT OF RIGHTS
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
 
-Subject to the terms and conditions of this License, the Licensor grants You
-a limited, non-exclusive, non-transferable, non-sublicensable license to:
+## Noncommercial Purposes
 
-1. Use the Licensed Work for personal, non-commercial purposes.
-2. Read and study the source code for educational purposes.
-3. Modify the Licensed Work solely for Your own personal use, provided that
-   modified versions are not distributed to third parties.
-4. Submit contributions (pull requests, patches, suggestions) to the official
-   True Recall repository. By submitting a contribution, You agree that Your
-   contribution is made under the same terms as this License and that the
-   Licensor may incorporate and distribute it under any license, including
-   proprietary ones.
+Any noncommercial purpose is a permitted purpose.
 
-RESTRICTIONS
+## Personal Uses
 
-You may NOT, without explicit prior written permission from the Licensor:
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
 
-1. Distribute, publish, or make available the Licensed Work or any derivative
-   work to any third party, whether modified or unmodified.
-2. Use the Licensed Work, in whole or in part, to create or operate a
-   Competing Product.
-3. Use the Licensed Work for Commercial Use, including offering it as a
-   hosted or managed service, selling access to it, or incorporating it into
-   a commercial product.
-4. Sublicense, sell, rent, lease, or transfer the Licensed Work or any rights
-   under this License to any third party.
-5. Remove or alter any copyright notices, license notices, or other
-   proprietary markings contained in the Licensed Work.
+## Noncommercial Organizations
 
-COMMERCIAL LICENSING
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
 
-If You wish to use the Licensed Work for Commercial Use, create a Competing
-Product, or distribute the Licensed Work beyond what is permitted above,
-You must obtain a separate commercial license from the Licensor.
+## Fair Use
 
-For commercial licensing inquiries, contact: pieralukasz@gmail.com
+You may have "fair use" rights for the software under the law. These terms do not limit them.
 
-DISCLAIMER OF WARRANTY
+## No Other Rights
 
-THE LICENSED WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-LICENSOR BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
-ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN
-CONNECTION WITH THE LICENSED WORK OR THE USE OR OTHER DEALINGS IN THE
-LICENSED WORK.
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
 
-TERMINATION
+## Patent Defense
 
-Your rights under this License terminate automatically if You fail to comply
-with any of its terms. Upon termination, You must cease all use and
-distribution of the Licensed Work and destroy all copies in Your possession.
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -92,12 +92,17 @@ True Recall is local-first. No telemetry, analytics, or background data transmis
 
 ## License
 
-Source-available under the [True Recall Source-Available License 1.0](LICENSE)
-(SPDX: `LicenseRef-True-Recall-Source-Available-1.0`).
+Source-available under the [PolyForm Strict License 1.0.0](LICENSE)
+(SPDX: `PolyForm-Strict-1.0.0`).
 
-Permitted: personal, non-commercial use; reading and studying the source;
-local modifications for your own use; submitting contributions upstream.
+Permitted: noncommercial use, including personal study, research, hobby
+projects, and use by charitable / educational / public-research / government
+organizations. Fair-use rights are preserved.
 
-Not permitted without prior written permission: redistribution, commercial use,
-hosting as a service, or building a competing product. For commercial licensing,
-contact `pieralukasz@gmail.com`.
+Not permitted under this license: redistribution, modification and derivative
+works, commercial use, hosting as a service, or building a competing product.
+
+**Commercial licensing.** A separate commercial license is required for any
+use beyond what PolyForm Strict allows — including production deployments
+inside a business, paid services built on True Recall, or distributing
+derivative works. Contact `pieralukasz@gmail.com` to discuss terms.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "true-recall",
 	"name": "True Recall",
-	"version": "1.9.1",
+	"version": "1.9.2",
 	"minAppVersion": "1.8.0",
 	"description": "Review flashcards with FSRS spaced repetition. Supports Anki import/export, projects, and detailed statistics.",
 	"author": "Lucas Piera",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "true-recall",
-	"version": "1.9.1",
+	"version": "1.9.2",
 	"private": true,
 	"description": "Spaced repetition with FSRS algorithm",
 	"main": "main.js",
@@ -26,7 +26,7 @@
 		"knip": "bunx knip"
 	},
 	"keywords": [],
-	"license": "LicenseRef-True-Recall-Source-Available-1.0",
+	"license": "PolyForm-Strict-1.0.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.4.2",
 		"@tailwindcss/cli": "^4.2.0",


### PR DESCRIPTION
## Summary

- Replace the custom **True Recall Source-Available License 1.0** with the canonical [**PolyForm Strict 1.0.0**](https://polyformproject.org/licenses/strict/1.0.0/) text so GitHub's license detector recognizes the repository. This resolves the **\"repository does not have a recognized license\"** warning from the Obsidian Community Portal automated review.
- The license restrictions are equivalent: noncommercial use only, no redistribution, no modifications/derivatives, no competing products. Commercial licensing remains available — README points to the contact email.
- Bump version 1.9.1 → 1.9.2 (manifest + package + CHANGELOG).

## Test plan

- [x] `bun run build` succeeds
- [x] `bun run test` — 2081 tests pass
- [x] CI green on this PR
- [ ] After merge: promote main → pre-release → release, tag 1.9.2, GH Release workflow publishes with attestation