### PR TITLE
feat: configurable storage locations for attachments, Anki import, and projects

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -271,6 +271,10 @@ export const DEFAULT_SETTINGS: TrueRecallSettings = {
 
 	generationPresets: [BUILTIN_BASIC_PRESET, BUILTIN_BASIC_PRO_PRESET],
 	defaultGenerationPresetId: BUILTIN_BASIC_PRESET_ID,
+
+	attachmentFolder: "",
+	defaultAnkiImportFolder: "",
+	defaultProjectFolder: "",
 };
 
 // FSRS v6 default weights (21 parameters)

--- a/packages/core/src/types/settings.types.ts
+++ b/packages/core/src/types/settings.types.ts
@@ -408,6 +408,23 @@ export interface TrueRecallSettings {
 	generationPresets: GenerationPreset[];
 	/** ID of the default generation preset */
 	defaultGenerationPresetId: string;
+
+	/**
+	 * Overrides where True Recall writes binary attachments: pasted images,
+	 * Image Occlusion crops, AI-generated card images, and Anki import media.
+	 * Empty string = each feature keeps its own pre-existing fallback behavior.
+	 */
+	attachmentFolder: string;
+	/**
+	 * Pre-fills the notes-destination folder field in the Anki import modal.
+	 * Empty string = modal keeps its built-in "Anki Import" default.
+	 */
+	defaultAnkiImportFolder: string;
+	/**
+	 * Pre-fills the folder field when creating a new top-level project note.
+	 * Empty string = vault root.
+	 */
+	defaultProjectFolder: string;
 }
 
 export interface SessionPreset {

--- a/packages/obsidian/src/features/integration/services/ImageService.ts
+++ b/packages/obsidian/src/features/integration/services/ImageService.ts
@@ -1,12 +1,12 @@
 import { type App, normalizePath, TFile } from "obsidian";
 
-import type { TrueRecallSettings } from "@true-recall/core/types/settings.types";
 import {
 	isImageExtension,
 	isVideoExtension,
 	MAX_IMAGE_SIZE_BYTES,
 	MAX_VIDEO_SIZE_BYTES,
 } from "@true-recall/core/types";
+import type { TrueRecallSettings } from "@true-recall/core/types/settings.types";
 
 import { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-folder";
 

--- a/packages/obsidian/src/features/integration/services/ImageService.ts
+++ b/packages/obsidian/src/features/integration/services/ImageService.ts
@@ -1,5 +1,6 @@
 import { type App, normalizePath, TFile } from "obsidian";
 
+import type { TrueRecallSettings } from "@true-recall/core/types/settings.types";
 import {
 	isImageExtension,
 	isVideoExtension,
@@ -7,11 +8,15 @@ import {
 	MAX_VIDEO_SIZE_BYTES,
 } from "@true-recall/core/types";
 
+import { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-folder";
+
 export class ImageService {
 	private app: App;
+	private getSettings: () => TrueRecallSettings;
 
-	constructor(app: App) {
+	constructor(app: App, getSettings: () => TrueRecallSettings) {
 		this.app = app;
+		this.getSettings = getSettings;
 	}
 
 	async saveImageFromClipboard(blob: Blob): Promise<string> {
@@ -35,6 +40,13 @@ export class ImageService {
 	}
 
 	getAttachmentFolder(): string {
+		return resolveAttachmentFolder(
+			this.getSettings().attachmentFolder,
+			this.getObsidianDefaultAttachmentFolder(),
+		);
+	}
+
+	private getObsidianDefaultAttachmentFolder(): string {
 		const attachmentFolderPath = (
 			this.app.vault as unknown as { getConfig: (key: string) => string }
 		).getConfig("attachmentFolderPath");

--- a/packages/obsidian/src/features/study/ui/dashboard/helpers/use-note-bulk-actions.ts
+++ b/packages/obsidian/src/features/study/ui/dashboard/helpers/use-note-bulk-actions.ts
@@ -23,7 +23,10 @@ export function useNoteBulkActions({
 	const handleCreateProjectFromSelected = useCallback(async () => {
 		if (selectedPaths.value.size === 0) return;
 
-		const modal = new CreateProjectModal(plugin.app);
+		const modal = new CreateProjectModal(
+			plugin.app,
+			plugin.settings.defaultProjectFolder,
+		);
 		const result = await modal.openAndWait();
 		if (result.cancelled) return;
 

--- a/packages/obsidian/src/modals/study/CreateProjectModal.tsx
+++ b/packages/obsidian/src/modals/study/CreateProjectModal.tsx
@@ -13,13 +13,15 @@ interface CreateProjectResult {
 
 function CreateProjectBody({
 	app,
+	initialFolder,
 	onResolve,
 }: {
 	app: App;
+	initialFolder: string;
 	onResolve: (result: CreateProjectResult) => void;
 }) {
 	const [name, setName] = useState("");
-	const [folder, setFolder] = useState("");
+	const [folder, setFolder] = useState(initialFolder);
 	const nameRef = useRef<HTMLInputElement>(null);
 
 	useEffect(() => {
@@ -78,11 +80,14 @@ function CreateProjectBody({
 }
 
 export class CreateProjectModal extends BasePromiseModal<CreateProjectResult> {
-	constructor(app: App) {
+	private initialFolder: string;
+
+	constructor(app: App, initialFolder = "") {
 		super(app, {
 			title: "Create new project",
 			width: "450px",
 		});
+		this.initialFolder = initialFolder;
 	}
 
 	protected getDefaultResult(): CreateProjectResult {
@@ -93,6 +98,7 @@ export class CreateProjectModal extends BasePromiseModal<CreateProjectResult> {
 		render(
 			<CreateProjectBody
 				app={this.app}
+				initialFolder={this.initialFolder}
 				onResolve={(result) => this.resolve(result)}
 			/>,
 			container,

--- a/packages/obsidian/src/services/image-post-processor.ts
+++ b/packages/obsidian/src/services/image-post-processor.ts
@@ -6,6 +6,7 @@ import type { SqliteStoreService } from "@true-recall/core/persistence/sqlite/Sq
 import type { TrueRecallSettings } from "@true-recall/core/types/settings.types";
 
 import { mutate } from "@true-recall/obsidian/data";
+import { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-folder";
 
 const IMAGE_DIR = ".true-recall/images";
 const IMAGE_API_URL = LITELLM_URL.replace(
@@ -53,16 +54,26 @@ export class ImagePostProcessor {
 	): Promise<void> {
 		if (fields.length === 0) return;
 
+		const imageDir = resolveAttachmentFolder(
+			this.getSettings().attachmentFolder,
+			IMAGE_DIR,
+		);
+
 		const adapter = this.app.vault.adapter;
-		if (!(await adapter.exists(IMAGE_DIR))) {
-			await adapter.mkdir(IMAGE_DIR);
+		if (!(await adapter.exists(imageDir))) {
+			await adapter.mkdir(imageDir);
 		}
 
 		let updated = false;
 		for (const cardId of cardIds) {
 			for (const field of fields) {
 				try {
-					const didUpdate = await this.processCardField(cardId, field, adapter);
+					const didUpdate = await this.processCardField(
+						cardId,
+						field,
+						adapter,
+						imageDir,
+					);
 					if (didUpdate) updated = true;
 				} catch (e) {
 					console.warn(
@@ -82,6 +93,7 @@ export class ImagePostProcessor {
 		cardId: string,
 		field: ImageFieldConfig,
 		adapter: VaultAdapter,
+		imageDir: string,
 	): Promise<boolean> {
 		const card = this.cardStore.cards.get(cardId);
 		if (!card?.noteId) return false;
@@ -106,7 +118,7 @@ export class ImagePostProcessor {
 			: `${sourceText}. Simple, clear illustration. No text, no words, no letters.`;
 
 		const hash = this.hashText(`${sourceText}:${field.style ?? ""}`);
-		const imagePath = `${IMAGE_DIR}/${hash}.png`;
+		const imagePath = `${imageDir}/${hash}.png`;
 
 		if (await adapter.exists(imagePath)) {
 			this.updateNoteField(

--- a/packages/obsidian/src/services/project-management.service.ts
+++ b/packages/obsidian/src/services/project-management.service.ts
@@ -60,7 +60,10 @@ export class ProjectManagementService {
 	async createSubProject(name: string, parentPath: string): Promise<void> {
 		const parentName =
 			parentPath.split("/").pop()?.replace(/\.md$/, "") ?? parentPath;
-		const projectPath = normalizePath(`${name}.md`);
+		const parentFolder = folderFromPath(parentPath);
+		const projectPath = normalizePath(
+			parentFolder ? `${parentFolder}/${name}.md` : `${name}.md`,
+		);
 
 		if (this.app.vault.getAbstractFileByPath(projectPath)) {
 			new Notice(`A note already exists at "${projectPath}".`);
@@ -272,4 +275,9 @@ export class ProjectManagementService {
 
 function nameFromPath(path: string): string {
 	return path.split("/").pop()?.replace(/\.md$/, "") ?? path;
+}
+
+export function folderFromPath(path: string): string {
+	const lastSlash = path.lastIndexOf("/");
+	return lastSlash >= 0 ? path.slice(0, lastSlash) : "";
 }

--- a/packages/obsidian/src/settings/tabs/DataTab.tsx
+++ b/packages/obsidian/src/settings/tabs/DataTab.tsx
@@ -8,12 +8,14 @@ import {
 	ManualBackupSection,
 	SmartRetentionSection,
 	StorageDiagnosticsSection,
+	StorageLocationsSection,
 } from "./data";
 
 export function DataTab() {
 	return (
 		<div class="ep:flex ep:flex-col ep:gap-3">
 			<DeviceDatabaseSection />
+			<StorageLocationsSection />
 			<ManualBackupSection />
 			<BackupSettingsSection />
 			<BackgroundBackupSection />

--- a/packages/obsidian/src/settings/tabs/data/StorageLocationsSection.tsx
+++ b/packages/obsidian/src/settings/tabs/data/StorageLocationsSection.tsx
@@ -1,0 +1,53 @@
+import {
+	FolderSuggestInput,
+	FormCard,
+	FormField,
+} from "@true-recall/obsidian/components";
+import { useApp } from "@true-recall/obsidian/preact/ObsidianContext";
+
+import { useSettings } from "../../hooks/useSettings";
+
+export function StorageLocationsSection() {
+	const app = useApp();
+	const { settings, save } = useSettings();
+
+	return (
+		<FormCard title="Storage locations">
+			<FormField
+				name="Attachment folder"
+				description="Where pasted images, Image Occlusion crops, AI-generated card images, and Anki import media are saved. Leave empty to keep each feature's current default location."
+			>
+				<FolderSuggestInput
+					app={app}
+					value={settings.attachmentFolder}
+					onChange={(v) => void save({ attachmentFolder: v })}
+					placeholder="Feature-specific default"
+				/>
+			</FormField>
+
+			<FormField
+				name="Default Anki import folder"
+				description="Pre-fills the notes destination when importing an Anki deck. Still editable per import."
+			>
+				<FolderSuggestInput
+					app={app}
+					value={settings.defaultAnkiImportFolder}
+					onChange={(v) => void save({ defaultAnkiImportFolder: v })}
+					placeholder="Anki Import"
+				/>
+			</FormField>
+
+			<FormField
+				name="Default project folder"
+				description="Pre-fills the folder field when creating a new project. Still editable per project."
+			>
+				<FolderSuggestInput
+					app={app}
+					value={settings.defaultProjectFolder}
+					onChange={(v) => void save({ defaultProjectFolder: v })}
+					placeholder="Vault root"
+				/>
+			</FormField>
+		</FormCard>
+	);
+}

--- a/packages/obsidian/src/settings/tabs/data/index.ts
+++ b/packages/obsidian/src/settings/tabs/data/index.ts
@@ -7,3 +7,4 @@ export { IntegrityCheckSection } from "./IntegrityCheckSection";
 export { ManualBackupSection } from "./ManualBackupSection";
 export { SmartRetentionSection } from "./SmartRetentionSection";
 export { StorageDiagnosticsSection } from "./StorageDiagnosticsSection";
+export { StorageLocationsSection } from "./StorageLocationsSection";

--- a/packages/obsidian/src/utils/attachment-folder.ts
+++ b/packages/obsidian/src/utils/attachment-folder.ts
@@ -1,0 +1,6 @@
+export function resolveAttachmentFolder(
+	attachmentFolderOverride: string,
+	fallbackFolder: string,
+): string {
+	return attachmentFolderOverride.trim() || fallbackFolder;
+}

--- a/packages/obsidian/src/utils/index.ts
+++ b/packages/obsidian/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { cn } from "@true-recall/obsidian/utils/cn";
+export { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-folder";

--- a/packages/obsidian/src/utils/index.ts
+++ b/packages/obsidian/src/utils/index.ts
@@ -1,2 +1,2 @@
-export { cn } from "@true-recall/obsidian/utils/cn";
 export { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-folder";
+export { cn } from "@true-recall/obsidian/utils/cn";

--- a/packages/obsidian/tests/services/project-management.service.test.ts
+++ b/packages/obsidian/tests/services/project-management.service.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { folderFromPath } from "@true-recall/obsidian/services/project-management.service";
+
+describe("folderFromPath", () => {
+	it("returns the containing folder for a nested path", () => {
+		expect(folderFromPath("Projects/Foo.md")).toBe("Projects");
+	});
+
+	it("returns an empty string for a vault-root path", () => {
+		expect(folderFromPath("Foo.md")).toBe("");
+	});
+
+	it("returns the full nested folder for a deeply nested path", () => {
+		expect(folderFromPath("Projects/Work/Foo.md")).toBe("Projects/Work");
+	});
+});

--- a/packages/obsidian/tests/utils/attachment-folder.test.ts
+++ b/packages/obsidian/tests/utils/attachment-folder.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-folder";
+
+describe("resolveAttachmentFolder", () => {
+	it("returns the override when it is set", () => {
+		expect(resolveAttachmentFolder("Flashcards/Attachments", "Attachments")).toBe(
+			"Flashcards/Attachments",
+		);
+	});
+
+	it("falls back when the override is an empty string", () => {
+		expect(resolveAttachmentFolder("", "Attachments")).toBe("Attachments");
+	});
+
+	it("falls back when the override is whitespace-only", () => {
+		expect(resolveAttachmentFolder("   ", "Attachments")).toBe("Attachments");
+	});
+
+	it("trims the override before returning it", () => {
+		expect(resolveAttachmentFolder("  Flashcards  ", "Attachments")).toBe(
+			"Flashcards",
+		);
+	});
+});

--- a/packages/obsidian/tests/utils/attachment-folder.test.ts
+++ b/packages/obsidian/tests/utils/attachment-folder.test.ts
@@ -4,9 +4,9 @@ import { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-
 
 describe("resolveAttachmentFolder", () => {
 	it("returns the override when it is set", () => {
-		expect(resolveAttachmentFolder("Flashcards/Attachments", "Attachments")).toBe(
-			"Flashcards/Attachments",
-		);
+		expect(
+			resolveAttachmentFolder("Flashcards/Attachments", "Attachments"),
+		).toBe("Flashcards/Attachments");
 	});
 
 	it("falls back when the override is an empty string", () => {

--- a/packages/plugins/src/anki-import-export/AnkiImportModal.tsx
+++ b/packages/plugins/src/anki-import-export/AnkiImportModal.tsx
@@ -26,6 +26,7 @@ import { ObsidianPersistence } from "@true-recall/obsidian/adapters/ObsidianPers
 import { ObsidianVaultFileReader } from "@true-recall/obsidian/adapters/ObsidianVaultFileReader";
 import { mutate } from "@true-recall/obsidian/data";
 import { BaseModal } from "@true-recall/obsidian/modals/shared/BaseModal";
+import { resolveAttachmentFolder } from "@true-recall/obsidian/utils/attachment-folder";
 
 import {
 	ErrorPhase,
@@ -46,6 +47,8 @@ const DEFAULT_IMPORT_FOLDER = "Anki Import";
 
 function AnkiImportBody({
 	app,
+	initialImportFolder,
+	attachmentFolderOverride,
 	onFileSelected,
 	onShowMapping,
 	onImport,
@@ -55,6 +58,8 @@ function AnkiImportBody({
 	aiKeyAvailable,
 }: {
 	app: App;
+	initialImportFolder: string;
+	attachmentFolderOverride: string;
 	onFileSelected: (file: File) => Promise<ImportPhase>;
 	onShowMapping: (preview: ImportPreview) => ImportPhase;
 	onImport: (opts: {
@@ -74,7 +79,7 @@ function AnkiImportBody({
 	const [importScheduling, setImportScheduling] = useState(true);
 	const [importMedia, setImportMedia] = useState(true);
 	const [useAI, setUseAI] = useState(false);
-	const [importFolder, setImportFolder] = useState(DEFAULT_IMPORT_FOLDER);
+	const [importFolder, setImportFolder] = useState(initialImportFolder);
 
 	const handleFile = useCallback(
 		async (file: File) => {
@@ -154,6 +159,7 @@ function AnkiImportBody({
 					useAI={useAI}
 					hasAIKey={aiKeyAvailable}
 					importFolder={importFolder}
+					attachmentFolderOverride={attachmentFolderOverride}
 					onSchedulingChange={setImportScheduling}
 					onMediaChange={setImportMedia}
 					onUseAIChange={setUseAI}
@@ -201,11 +207,16 @@ export class AnkiImportModal extends BaseModal {
 
 	protected renderBody(container: HTMLElement): void {
 		const existingNoteTypes = this.store.noteTypes.getAll();
-		const aiKeyAvailable = hasAIKey(this.getSettings());
+		const settings = this.getSettings();
+		const aiKeyAvailable = hasAIKey(settings);
 
 		render(
 			<AnkiImportBody
 				app={this.app}
+				initialImportFolder={
+					settings.defaultAnkiImportFolder || DEFAULT_IMPORT_FOLDER
+				}
+				attachmentFolderOverride={settings.attachmentFolder}
 				onFileSelected={(file) => this.handleFileSelected(file)}
 				onShowMapping={(preview) => this.buildMappingPhase(preview)}
 				onImport={(opts) => this.startImport(opts)}
@@ -307,7 +318,10 @@ export class AnkiImportModal extends BaseModal {
 			)
 				.replace(/[\\/:*?"<>|]/g, "-")
 				.trim();
-			const mediaFolder = `Attachments/${opts.importFolder}/${topDeck}`;
+			const mediaFolder = resolveAttachmentFolder(
+				this.getSettings().attachmentFolder,
+				`Attachments/${opts.importFolder}/${topDeck}`,
+			);
 
 			const result = await importService.importCards(
 				this.apkgData,

--- a/packages/plugins/src/anki-import-export/anki-import/PreviewPhase.tsx
+++ b/packages/plugins/src/anki-import-export/anki-import/PreviewPhase.tsx
@@ -18,6 +18,7 @@ interface PreviewPhaseProps {
 	useAI: boolean;
 	hasAIKey: boolean;
 	importFolder: string;
+	attachmentFolderOverride: string;
 	onSchedulingChange: (val: boolean) => void;
 	onMediaChange: (val: boolean) => void;
 	onUseAIChange: (val: boolean) => void;
@@ -34,6 +35,7 @@ export function PreviewPhase({
 	useAI: _useAI,
 	hasAIKey: _hasAIKey,
 	importFolder,
+	attachmentFolderOverride,
 	onSchedulingChange,
 	onMediaChange,
 	onUseAIChange: _onUseAIChange,
@@ -76,7 +78,9 @@ export function PreviewPhase({
 				/>
 				<OptionCheckbox
 					label="Import media files"
-					description={`${preview.mediaCount} files will be saved to Attachments/${importFolder}`}
+					description={`${preview.mediaCount} files will be saved to ${
+						attachmentFolderOverride || `Attachments/${importFolder}`
+					}`}
 					checked={importMedia}
 					onChange={onMediaChange}
 				/>

--- a/packages/plugins/src/image-occlusion/components/IOEditorApp.tsx
+++ b/packages/plugins/src/image-occlusion/components/IOEditorApp.tsx
@@ -91,7 +91,10 @@ export function IOEditorApp({ mode, onDone }: IOEditorAppProps) {
 	const [aiPromptVisible, setAiPromptVisible] = useState(false);
 	const [aiCustomHint, setAiCustomHint] = useState("");
 
-	const imageService = useMemo(() => new ImageService(app), [app]);
+	const imageService = useMemo(
+		() => new ImageService(app, () => plugin.settings),
+		[app, plugin],
+	);
 	const isEdit = mode.mode === "edit";
 	const showSourcePicker = mode.mode === "add" && !mode.sourceUid;
 	const hasRegions = definition.regions.length > 0;


### PR DESCRIPTION
## Summary
- Adds a "Storage locations" settings section (Data & Backup tab) with three new overrides: attachment folder, default Anki import folder, default project folder — all empty by default so existing vaults see no behavior change.
- Unifies three previously-inconsistent attachment write paths (pasted images/Image Occlusion, AI-generated card images, Anki import media) onto the same attachment-folder override when it's set.
- Fixes sub-projects always being created at vault root regardless of their parent project's folder — they now inherit the parent's folder.

Prompted by a Discord question asking whether projects/attachments/Anki imports could be saved to a specific folder. Design doc and implementation plan are local-only (docs/ is gitignored in this repo).

## Test plan
- [x] `bun run build` — typecheck + production bundle
- [x] `bun run test` — 2176 tests passing (150 files)
- [x] `bun run biome` — clean
- [x] Manual verification in a disposable Obsidian vault: default behavior unchanged, override behavior confirmed for attachment folder, Anki import folder default, project folder default, and sub-project folder inheritance