### PR TITLE
feat(fsrs): scheduling suite — auto/manual target, backlog spreading, Anki fuzz balancing, replay optimizer

### DIFF
--- a/cli/commands/fsrs-advanced.ts
+++ b/cli/commands/fsrs-advanced.ts
@@ -1,12 +1,15 @@
 import type { CommandDef } from "../registry.js";
-import { getWith, postParams } from "../registry.js";
+import { custom, getWith, postParams } from "../registry.js";
 
 const C = "FSRS Advanced";
 
+/** Replay-based training over the full review history takes minutes, not seconds */
+const OPTIMIZE_TIMEOUT_MS = 600_000;
+
 export const fsrsAdvancedCommands: CommandDef[] = [
-	getWith(
+	custom(
 		"optimize_parameters",
-		"Optimize FSRS weights from review history. Needs 400+ reviews.",
+		"Optimize FSRS weights from review history (replay-based training). Needs 400+ reviews; can take a few minutes.",
 		C,
 		{
 			preset_name: {
@@ -14,8 +17,11 @@ export const fsrsAdvancedCommands: CommandDef[] = [
 				description: "Scope to a specific preset (default: all)",
 			},
 		},
-		(p) =>
-			`/fsrs/optimize${p.preset_name ? `?preset_name=${encodeURIComponent(String(p.preset_name))}` : ""}`,
+		(p, client) =>
+			client.get(
+				`/fsrs/optimize${p.preset_name ? `?preset_name=${encodeURIComponent(String(p.preset_name))}` : ""}`,
+				OPTIMIZE_TIMEOUT_MS,
+			),
 	),
 
 	postParams(
@@ -43,7 +49,7 @@ export const fsrsAdvancedCommands: CommandDef[] = [
 
 	getWith(
 		"get_workload_forecast",
-		"Detailed daily workload forecast: predicted reviews per day + day-of-week breakdown",
+		"Detailed daily workload forecast: predicted reviews per day + day-of-week breakdown. Optionally scoped to one project.",
 		C,
 		{
 			days: {
@@ -51,8 +57,13 @@ export const fsrsAdvancedCommands: CommandDef[] = [
 				description: "Forecast period in days (default 30)",
 				default: 30,
 			},
+			project: {
+				type: "string",
+				description: "Project note path to scope the forecast to (optional)",
+			},
 		},
-		(p) => `/fsrs/forecast?days=${p.days}`,
+		(p) =>
+			`/fsrs/forecast?days=${p.days}${p.project ? `&project=${encodeURIComponent(String(p.project))}` : ""}`,
 	),
 
 	getWith(

--- a/cli/commands/fsrs.ts
+++ b/cli/commands/fsrs.ts
@@ -1,5 +1,5 @@
 import type { CommandDef } from "../registry.js";
-import { get, getWith, postParams } from "../registry.js";
+import { get, getWith, postParams, postTo } from "../registry.js";
 
 const C = "FSRS";
 
@@ -41,6 +41,93 @@ export const fsrsCommands: CommandDef[] = [
 			relearning_steps: {
 				type: "json",
 				description: "Relearning steps in minutes as JSON array, e.g. [10]",
+			},
+		},
+	),
+
+	postTo(
+		"update_fsrs_preset",
+		"Update an FSRS preset: retention target, daily limits, learning steps, leech handling",
+		C,
+		{
+			preset: {
+				type: "string",
+				description: "Preset id or name (e.g. Default)",
+				required: true,
+			},
+			request_retention: {
+				type: "number",
+				description: "Target retention rate 0.7-0.99",
+			},
+			new_cards_per_day: {
+				type: "number",
+				description: "Daily new cards limit (0 = pause new cards)",
+			},
+			reviews_per_day: {
+				type: "number",
+				description: "Daily reviews limit",
+			},
+			learning_steps: {
+				type: "json",
+				description: "Learning steps in minutes as JSON array, e.g. [1, 10]",
+			},
+			relearning_steps: {
+				type: "json",
+				description: "Relearning steps in minutes as JSON array, e.g. [10]",
+			},
+			leech_threshold: {
+				type: "number",
+				description: "Lapses before a card is tagged as leech",
+			},
+			leech_action: {
+				type: "string",
+				description: "What to do with leeches",
+				enum: ["tag-only", "suspend"],
+			},
+			weights: {
+				type: "json",
+				description:
+					"FSRS weights as JSON array of 21 numbers, or null to reset to defaults",
+			},
+		},
+		(p) => `/presets/${encodeURIComponent(String(p.preset))}`,
+		(p) => {
+			const { preset: _preset, ...body } = p;
+			return body;
+		},
+	),
+
+	postParams(
+		"set_load_balance",
+		"Update load balancing settings: enabled, target_mode (auto = forecast average), manual target, deviation, shift range",
+		C,
+		"/settings/load-balance",
+		{
+			enabled: {
+				type: "boolean",
+				description: "Enable/disable load balancing when scheduling reviews",
+			},
+			target_mode: {
+				type: "string",
+				description:
+					"How the daily target is set: auto (forecast average) or manual",
+				enum: ["auto", "manual"],
+			},
+			target: {
+				type: "number",
+				description: "Manual target reviews/day (used in manual mode)",
+			},
+			max_deviation: {
+				type: "number",
+				description: "Allowed deviation from target in percent (0-100)",
+			},
+			max_shift_days: {
+				type: "number",
+				description: "Max day shift when balancing a newly scheduled review",
+			},
+			bulk_days: {
+				type: "number",
+				description: "Day range for Balance now (0 = all future)",
 			},
 		},
 	),

--- a/mcp-server/client.ts
+++ b/mcp-server/client.ts
@@ -56,8 +56,8 @@ export class TrueRecallClient {
 		return body.data;
 	}
 
-	async get<T>(path: string): Promise<T> {
-		return this.request<T>(path);
+	async get<T>(path: string, timeoutMs?: number): Promise<T> {
+		return this.request<T>(path, undefined, timeoutMs);
 	}
 
 	async post<T>(path: string, data?: unknown): Promise<T> {

--- a/mcp-server/tools/fsrs-tools.ts
+++ b/mcp-server/tools/fsrs-tools.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { get, getWith, postParams, type ToolDef } from "./_register.js";
+import { get, getWith, postParams, postTo, type ToolDef } from "./_register.js";
 
 export const fsrsTools: ToolDef[] = [
 	get(
@@ -42,6 +42,89 @@ export const fsrsTools: ToolDef[] = [
 				.describe(
 					"Relearning steps in minutes, e.g. [10]. Used when a Review card is rated Again.",
 				),
+		},
+	),
+
+	postTo(
+		"update_fsrs_preset",
+		"Update an existing FSRS preset: retention target, daily limits, learning steps, leech handling. Identify the preset by id or name.",
+		{
+			preset: z.string().describe("Preset id or name (e.g. Default)"),
+			request_retention: z
+				.number()
+				.min(0.7)
+				.max(0.99)
+				.optional()
+				.describe(
+					"Target retention rate 0.7-0.99. Higher = more reviews but better recall.",
+				),
+			new_cards_per_day: z
+				.number()
+				.optional()
+				.describe("Daily new cards limit (0 = pause new cards)"),
+			reviews_per_day: z.number().optional().describe("Daily reviews limit"),
+			learning_steps: z
+				.array(z.number())
+				.optional()
+				.describe("Learning steps in minutes, e.g. [1, 10]"),
+			relearning_steps: z
+				.array(z.number())
+				.optional()
+				.describe("Relearning steps in minutes, e.g. [10]"),
+			leech_threshold: z
+				.number()
+				.optional()
+				.describe("Lapses before a card is tagged as leech"),
+			leech_action: z
+				.enum(["tag-only", "suspend"])
+				.optional()
+				.describe("What to do with leeches"),
+			weights: z
+				.array(z.number())
+				.nullable()
+				.optional()
+				.describe(
+					"FSRS weights as an array of 21 numbers, or null to reset to defaults",
+				),
+		},
+		(p) => `/presets/${encodeURIComponent(String(p.preset))}`,
+		(p) => {
+			const { preset: _preset, ...body } = p;
+			return body;
+		},
+	),
+
+	postParams(
+		"set_load_balance",
+		"Update load balancing settings: enable/disable, target mode (auto = forecast average, manual = fixed number), deviation, and shift range.",
+		"/settings/load-balance",
+		{
+			enabled: z
+				.boolean()
+				.optional()
+				.describe("Enable/disable load balancing when scheduling reviews"),
+			target_mode: z
+				.enum(["auto", "manual"])
+				.optional()
+				.describe(
+					"How the daily target is set: auto (forecast average) or manual",
+				),
+			target: z
+				.number()
+				.optional()
+				.describe("Manual target reviews/day (used in manual mode)"),
+			max_deviation: z
+				.number()
+				.optional()
+				.describe("Allowed deviation from target in percent (0-100)"),
+			max_shift_days: z
+				.number()
+				.optional()
+				.describe("Max day shift when balancing a newly scheduled review"),
+			bulk_days: z
+				.number()
+				.optional()
+				.describe("Day range for Balance now (0 = all future)"),
 		},
 	),
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -189,6 +189,7 @@ export const DEFAULT_SETTINGS: TrueRecallSettings = {
 	copilotAutoContext: false,
 
 	loadBalanceEnabled: false,
+	loadBalanceTargetMode: "auto",
 	loadBalanceTarget: 100,
 	loadBalanceMaxDeviation: 20,
 	loadBalanceMaxShiftDays: 3,

--- a/packages/core/src/metrics/fsrs-tools/fsrs-helper.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/fsrs-helper.service.ts
@@ -1,6 +1,7 @@
 import { State } from "ts-fsrs";
 
 import type { SqliteStoreService } from "../../persistence/sqlite/SqliteStoreService";
+import { formatLocalDate, getTodayBoundary } from "../../utils";
 import type {
 	FSRSCardData,
 	FSRSSettings,
@@ -96,11 +97,11 @@ export class FSRSHelperService {
 		);
 	}
 
-	optimizeParameters(
+	async optimizeParameters(
 		options?: OptimizerOptions,
 		presetName?: string,
 		currentWeights?: number[] | null,
-	): OptimizationOutput {
+	): Promise<OptimizationOutput> {
 		const reviews = this.cardStore.getReviewDataForOptimization(presetName);
 
 		const input: OptimizationInput = {
@@ -116,18 +117,47 @@ export class FSRSHelperService {
 		return this.optimizer.validateWeights(weights);
 	}
 
+	/** Manual target when configured, undefined in auto mode (core derives it) */
+	private resolveLoadBalanceTarget(): number | undefined {
+		return this.settings.loadBalanceTargetMode === "manual"
+			? this.settings.loadBalanceTarget
+			: undefined;
+	}
+
+	/** The daily target actually in effect: manual value or forecast average */
+	getEffectiveLoadBalanceTarget(): number {
+		return (
+			this.resolveLoadBalanceTarget() ??
+			this.loadBalancer.computeAutoTarget(
+				this.settings.easyDays,
+				this.settings.easyDaysMultiplier,
+			)
+		);
+	}
+
 	balanceWorkload(options?: Partial<LoadBalanceOptions>): SchedulingResult {
 		const days = options?.days ?? this.settings.loadBalanceBulkDays;
 		return this.loadBalancer.balance({
-			targetPerDay: options?.targetPerDay ?? this.settings.loadBalanceTarget,
+			targetPerDay: options?.targetPerDay ?? this.resolveLoadBalanceTarget(),
 			maxDeviation:
 				options?.maxDeviation ?? this.settings.loadBalanceMaxDeviation,
 			days: days === 0 ? 36500 : days,
 			easyDays: options?.easyDays ?? this.settings.easyDays,
 			easyDaysMultiplier:
 				options?.easyDaysMultiplier ?? this.settings.easyDaysMultiplier,
+			includeOverdue: options?.includeOverdue,
+			cardIds: options?.cardIds,
+			completedToday: options?.completedToday ?? this.getCompletedTodayCount(),
 			dryRun: options?.dryRun ?? true,
 		});
+	}
+
+	/** Reviews already answered today, respecting the day-start-hour boundary */
+	private getCompletedTodayCount(): number {
+		const todayKey = formatLocalDate(
+			getTodayBoundary(this.settings.dayStartHour ?? 4),
+		);
+		return this.cardStore.stats.getDailyStats(todayKey)?.reviewsCompleted ?? 0;
 	}
 
 	balanceScheduledReview(cardId: string, fsrs: FSRSCardData): FSRSCardData {
@@ -142,8 +172,6 @@ export class FSRSHelperService {
 		const result = this.loadBalancer.balanceDue({
 			cardId,
 			originalDue: fsrs.due,
-			targetPerDay: this.settings.loadBalanceTarget,
-			maxDeviation: this.settings.loadBalanceMaxDeviation,
 			maxShiftDays: this.settings.loadBalanceMaxShiftDays,
 			easyDays: this.settings.easyDays,
 			easyDaysMultiplier: this.settings.easyDaysMultiplier,
@@ -180,7 +208,8 @@ export class FSRSHelperService {
 		return this.easyDays.applyEasyDays({
 			easyDays: options?.easyDays ?? this.settings.easyDays,
 			multiplier: options?.multiplier ?? this.settings.easyDaysMultiplier,
-			targetPerDay: options?.targetPerDay ?? this.settings.loadBalanceTarget,
+			targetPerDay:
+				options?.targetPerDay ?? this.getEffectiveLoadBalanceTarget(),
 			days: options?.days ?? 30,
 			dryRun: options?.dryRun ?? true,
 		});
@@ -193,7 +222,7 @@ export class FSRSHelperService {
 		return this.easyDays.previewImpact(
 			this.settings.easyDays,
 			this.settings.easyDaysMultiplier,
-			this.settings.loadBalanceTarget,
+			this.getEffectiveLoadBalanceTarget(),
 		);
 	}
 
@@ -283,22 +312,33 @@ export class FSRSHelperService {
 	getWorkloadForecast(
 		days: number = 30,
 		excludeSourceUids?: ReadonlySet<string>,
+		includeSourceUids?: ReadonlySet<string>,
 	): WorkloadForecastEntry[] {
-		return this.workloadForecast.getForecast(days, excludeSourceUids);
+		return this.workloadForecast.getForecast(
+			days,
+			excludeSourceUids,
+			includeSourceUids,
+		);
 	}
 
 	getWorkloadForecastSummary(
 		days: number = 30,
 		excludeSourceUids?: ReadonlySet<string>,
+		includeSourceUids?: ReadonlySet<string>,
+		targetPerDay?: number,
 	): WorkloadForecastSummary {
 		const summary = this.workloadForecast.getSummary(
-			this.settings.loadBalanceTarget,
+			targetPerDay ?? this.getEffectiveLoadBalanceTarget(),
 			days,
 			excludeSourceUids,
 			this.settings.loadBalanceMaxDeviation,
+			includeSourceUids,
 		);
 
-		if (excludeSourceUids && excludeSourceUids.size > 0) return summary;
+		const isScoped =
+			(excludeSourceUids && excludeSourceUids.size > 0) ||
+			(includeSourceUids && includeSourceUids.size > 0);
+		if (isScoped) return summary;
 
 		return {
 			...summary,
@@ -313,10 +353,12 @@ export class FSRSHelperService {
 	getWorkloadByDayOfWeek(
 		days: number = 30,
 		excludeSourceUids?: ReadonlySet<string>,
+		includeSourceUids?: ReadonlySet<string>,
 	): { day: number; dayName: string; avgCount: number }[] {
 		return this.workloadForecast.getWorkloadByDayOfWeek(
 			days,
 			excludeSourceUids,
+			includeSourceUids,
 		);
 	}
 
@@ -347,8 +389,6 @@ export class FSRSHelperService {
 		const result = this.loadBalancer.balanceDue({
 			cardId,
 			originalDue: entry.due.toISOString(),
-			targetPerDay: this.settings.loadBalanceTarget,
-			maxDeviation: this.settings.loadBalanceMaxDeviation,
 			maxShiftDays: this.settings.loadBalanceMaxShiftDays,
 			easyDays: this.settings.easyDays,
 			easyDaysMultiplier: this.settings.easyDaysMultiplier,
@@ -361,7 +401,7 @@ export class FSRSHelperService {
 				originalInterval: entry.interval,
 				daysChanged: 0,
 				loadBalanceNote:
-					"No change: the FSRS target day is within the workload limit, or no better nearby day is available.",
+					"No change: the FSRS day is already a good fit within the fuzz range.",
 			};
 		}
 
@@ -375,15 +415,27 @@ export class FSRSHelperService {
 			balancedDue,
 			originalInterval: entry.interval,
 			daysChanged: result.daysChanged,
-			loadBalanceNote: "Adjusted to a nearby day with more review capacity.",
+			loadBalanceNote:
+				"Adjusted within the fuzz range to a less loaded day (Anki-style).",
 		};
 	}
 
+	/**
+	 * Scheduling parameters for rescheduling. Presets are the source of
+	 * truth since optimization writes there; the flat fsrsWeights /
+	 * fsrsRequestRetention fields are a stale legacy mirror kept as
+	 * fallback for pre-preset settings files.
+	 */
 	private extractFSRSSettings(): FSRSSettings {
+		const defaultPreset = this.settings.fsrsPresets?.find(
+			(preset) => preset.id === this.settings.defaultPresetId,
+		);
 		return {
-			requestRetention: this.settings.fsrsRequestRetention,
-			maximumInterval: this.settings.fsrsMaximumInterval,
-			weights: this.settings.fsrsWeights,
+			requestRetention:
+				defaultPreset?.requestRetention ?? this.settings.fsrsRequestRetention,
+			maximumInterval:
+				defaultPreset?.maximumInterval ?? this.settings.fsrsMaximumInterval,
+			weights: defaultPreset?.weights ?? this.settings.fsrsWeights,
 			enableFuzz: true,
 			learningSteps: this.settings.learningSteps,
 			relearningSteps: this.settings.relearningSteps,

--- a/packages/core/src/metrics/fsrs-tools/optimizer/parameter-optimizer.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/optimizer/parameter-optimizer.service.ts
@@ -1,10 +1,26 @@
 /**
  * FSRS Parameter Optimizer Service
+ *
+ * Replay-based training: every candidate weight vector re-simulates each
+ * card's full review history through ts-fsrs state equations, then scores
+ * the predicted recall probability against the actual outcome. This makes
+ * all 21 parameters observable in the loss — unlike scoring against the
+ * stability stored in the logs, which was produced by the old weights and
+ * leaves every parameter except the forgetting-curve decay with a zero
+ * gradient.
+ *
+ * FSRS convention: Hard is a successful recall; only Again is a lapse.
  */
 
-import { forgetting_curve, Rating, type State } from "ts-fsrs";
+import {
+	clipParameters,
+	default_w,
+	FSRSAlgorithm,
+	generatorParameters,
+	Rating,
+} from "ts-fsrs";
 
-import { DEFAULT_FSRS_WEIGHTS } from "../../../constants";
+import type { Grade } from "../../../types";
 import type {
 	OptimizationInput,
 	OptimizationOutput,
@@ -13,29 +29,46 @@ import type {
 } from "./optimizer.types";
 
 const MIN_REVIEWS_FOR_OPTIMIZATION = 400;
-const MAX_ITERATIONS = 1000;
-const LEARNING_RATE = 0.01;
-const CONVERGENCE_THRESHOLD = 1e-6;
+const MAX_ITERATIONS = 150;
+/** Stop when the loss improves less than this (relative) for PATIENCE iterations */
+const CONVERGENCE_THRESHOLD = 1e-5;
+const PATIENCE = 8;
 
-interface TrainingDataPoint {
+const ADAM_LEARNING_RATE = 0.04;
+const ADAM_BETA1 = 0.9;
+const ADAM_BETA2 = 0.999;
+const ADAM_EPSILON = 1e-8;
+
+/** Clamp for predicted recall inside the log-loss */
+const MIN_PREDICTION = 0.001;
+const MAX_PREDICTION = 0.999;
+
+interface ReviewStep {
 	elapsedDays: number;
-	stability: number;
-	difficulty: number;
-	state: State;
-	rating: number;
-	wasRecalled: boolean;
+	rating: Grade;
+}
+
+interface ReplayMetrics {
+	avgLoss: number;
+	rmse: number;
+	predictionCount: number;
+}
+
+/** FSRS training label: Hard/Good/Easy are successful recalls, Again is not */
+export function isRecalled(rating: Grade): boolean {
+	return rating > Rating.Again;
 }
 
 export class ParameterOptimizerService {
-	optimize(
+	async optimize(
 		input: OptimizationInput,
 		options?: OptimizerOptions,
-	): OptimizationOutput {
+	): Promise<OptimizationOutput> {
 		const minReviews = input.minReviews ?? MIN_REVIEWS_FOR_OPTIMIZATION;
 
 		if (input.reviews.length < minReviews) {
 			return {
-				weights: input.currentWeights ?? [...DEFAULT_FSRS_WEIGHTS],
+				weights: input.currentWeights ?? [...default_w],
 				metrics: {
 					rmse: 0,
 					logLoss: 0,
@@ -45,66 +78,84 @@ export class ParameterOptimizerService {
 			};
 		}
 
-		const trainingData = this.prepareTrainingData(input.reviews);
+		const sequences = this.prepareSequences(input.reviews);
+		const startWeights = clipParameters(
+			[...(input.currentWeights ?? default_w)],
+			0,
+		);
 
-		let weights = input.currentWeights
-			? [...input.currentWeights]
-			: [...DEFAULT_FSRS_WEIGHTS];
+		let weights = [...startWeights];
+		let bestWeights = [...weights];
+		let bestLoss = this.evaluate(weights, sequences).avgLoss;
 
-		let previousLoss = Infinity;
+		const m = new Array<number>(weights.length).fill(0);
+		const v = new Array<number>(weights.length).fill(0);
+		let previousLoss = bestLoss;
+		let stagnantIterations = 0;
 		let convergenceStatus: OptimizationOutput["metrics"]["convergenceStatus"] =
 			"max_iterations";
 
-		for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-			if (options?.abortSignal?.aborted) {
-				break;
-			}
+		for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+			if (options?.abortSignal?.aborted) break;
 
-			const { loss, gradients } = this.calculateLossAndGradients(
-				weights,
-				trainingData,
-			);
+			const base = this.evaluate(weights, sequences);
+			if (base.avgLoss < bestLoss) {
+				bestLoss = base.avgLoss;
+				bestWeights = [...weights];
+			}
 
 			options?.onProgress?.({
 				iteration,
 				totalIterations: MAX_ITERATIONS,
-				currentLoss: loss,
+				currentLoss: base.avgLoss,
 			});
 
-			if (Math.abs(previousLoss - loss) < CONVERGENCE_THRESHOLD) {
+			const relativeChange =
+				Math.abs(previousLoss - base.avgLoss) / Math.max(previousLoss, 1e-9);
+			stagnantIterations =
+				relativeChange < CONVERGENCE_THRESHOLD ? stagnantIterations + 1 : 0;
+			if (stagnantIterations >= PATIENCE) {
 				convergenceStatus = "converged";
 				break;
 			}
+			previousLoss = base.avgLoss;
 
-			weights = weights.map((w, i) => {
+			const gradients = this.numericGradients(weights, sequences, base.avgLoss);
+
+			for (let i = 0; i < weights.length; i++) {
 				const grad = gradients[i] ?? 0;
-				const newW = w - LEARNING_RATE * grad;
-				return this.clipWeight(newW, i);
-			});
+				m[i] = ADAM_BETA1 * (m[i] ?? 0) + (1 - ADAM_BETA1) * grad;
+				v[i] = ADAM_BETA2 * (v[i] ?? 0) + (1 - ADAM_BETA2) * grad * grad;
+				const mHat = (m[i] ?? 0) / (1 - ADAM_BETA1 ** iteration);
+				const vHat = (v[i] ?? 0) / (1 - ADAM_BETA2 ** iteration);
+				weights[i] =
+					(weights[i] ?? 0) -
+					(ADAM_LEARNING_RATE * mHat) / (Math.sqrt(vHat) + ADAM_EPSILON);
+			}
+			weights = clipParameters(weights, 0);
 
-			previousLoss = loss;
+			// Keep the UI responsive — this runs on the plugin's main thread
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 		}
 
-		const finalMetrics = this.calculateMetrics(weights, trainingData);
+		const finalMetrics = this.evaluate(bestWeights, sequences);
 
 		let improvement: number | undefined;
 		if (input.currentWeights) {
-			const currentMetrics = this.calculateMetrics(
-				input.currentWeights,
-				trainingData,
-			);
-			if (currentMetrics.logLoss > 0) {
+			const currentMetrics = this.evaluate(startWeights, sequences);
+			if (currentMetrics.avgLoss > 0) {
 				improvement =
-					((currentMetrics.logLoss - finalMetrics.logLoss) /
-						currentMetrics.logLoss) *
+					((currentMetrics.avgLoss - finalMetrics.avgLoss) /
+						currentMetrics.avgLoss) *
 					100;
 			}
 		}
 
 		return {
-			weights,
+			weights: bestWeights,
 			metrics: {
-				...finalMetrics,
+				logLoss: finalMetrics.avgLoss,
+				rmse: finalMetrics.rmse,
 				reviewCount: input.reviews.length,
 				convergenceStatus,
 			},
@@ -112,154 +163,115 @@ export class ParameterOptimizerService {
 		};
 	}
 
-	private prepareTrainingData(
-		reviews: OptimizationReviewEntry[],
-	): TrainingDataPoint[] {
-		const dataPoints: TrainingDataPoint[] = [];
-
-		const cardReviews = new Map<string, OptimizationReviewEntry[]>();
+	/**
+	 * Group reviews into per-card chronological sequences. The first review
+	 * of a card initializes its memory state; later ones both score the
+	 * prediction (when at least a day elapsed) and advance the state.
+	 */
+	private prepareSequences(reviews: OptimizationReviewEntry[]): ReviewStep[][] {
+		const byCard = new Map<string, OptimizationReviewEntry[]>();
 		for (const review of reviews) {
-			const existing = cardReviews.get(review.cardId) ?? [];
+			const existing = byCard.get(review.cardId) ?? [];
 			existing.push(review);
-			cardReviews.set(review.cardId, existing);
+			byCard.set(review.cardId, existing);
 		}
 
-		for (const cardRevs of cardReviews.values()) {
-			cardRevs.sort((a, b) => a.reviewedAt - b.reviewedAt);
-
-			for (let i = 1; i < cardRevs.length; i++) {
-				const prev = cardRevs[i - 1];
-				const curr = cardRevs[i];
-
-				if (!prev || !curr) continue;
-
-				if (curr.elapsedDays > 0) {
-					dataPoints.push({
-						elapsedDays: curr.elapsedDays,
-						stability: prev.stability,
-						difficulty: prev.difficulty,
-						state: prev.state,
-						rating: curr.rating,
-						wasRecalled: curr.rating >= Rating.Good,
-					});
-				}
-			}
-		}
-
-		return dataPoints;
-	}
-
-	private calculateLossAndGradients(
-		weights: number[],
-		data: TrainingDataPoint[],
-	): { loss: number; gradients: number[] } {
-		const avgLoss = this.calculateLoss(weights, data);
-
-		const gradients = new Array<number>(weights.length).fill(0);
-		const epsilon = 1e-4;
-
-		for (let i = 0; i < weights.length; i++) {
-			const weightsPlus = [...weights];
-			const weightsMinus = [...weights];
-			weightsPlus[i] = (weightsPlus[i] ?? 0) + epsilon;
-			weightsMinus[i] = (weightsMinus[i] ?? 0) - epsilon;
-
-			const lossPlus = this.calculateLoss(weightsPlus, data);
-			const lossMinus = this.calculateLoss(weightsMinus, data);
-
-			gradients[i] = (lossPlus - lossMinus) / (2 * epsilon);
-		}
-
-		return { loss: avgLoss, gradients };
-	}
-
-	private calculateLoss(weights: number[], data: TrainingDataPoint[]): number {
-		let totalLoss = 0;
-
-		for (const point of data) {
-			const retrievability = forgetting_curve(
-				weights,
-				point.elapsedDays,
-				Math.max(point.stability, 0.1),
+		const sequences: ReviewStep[][] = [];
+		for (const cardReviews of byCard.values()) {
+			cardReviews.sort((a, b) => a.reviewedAt - b.reviewedAt);
+			sequences.push(
+				cardReviews.map((review) => ({
+					elapsedDays: Math.max(0, review.elapsedDays),
+					rating: review.rating,
+				})),
 			);
-			const clippedR = Math.max(0.001, Math.min(0.999, retrievability));
-
-			if (point.wasRecalled) {
-				totalLoss -= Math.log(clippedR);
-			} else {
-				totalLoss -= Math.log(1 - clippedR);
-			}
 		}
-
-		return totalLoss / Math.max(data.length, 1);
+		return sequences;
 	}
 
-	private calculateMetrics(
-		weights: number[],
-		data: TrainingDataPoint[],
-	): { rmse: number; logLoss: number } {
+	/** Replay all sequences with the given weights and score the predictions */
+	private evaluate(weights: number[], sequences: ReviewStep[][]): ReplayMetrics {
+		const algorithm = new FSRSAlgorithm(
+			generatorParameters({ w: weights, enable_short_term: true }),
+		);
+
 		let totalLoss = 0;
 		let totalSquaredError = 0;
+		let predictionCount = 0;
 
-		for (const point of data) {
-			const retrievability = forgetting_curve(
-				weights,
-				point.elapsedDays,
-				Math.max(point.stability, 0.1),
-			);
-			const clippedR = Math.max(0.001, Math.min(0.999, retrievability));
+		for (const sequence of sequences) {
+			let state: { stability: number; difficulty: number } | null = null;
+			for (const step of sequence) {
+				if (state && step.elapsedDays > 0) {
+					const retrievability = algorithm.forgetting_curve(
+						step.elapsedDays,
+						state.stability,
+					);
+					const clipped = Math.max(
+						MIN_PREDICTION,
+						Math.min(MAX_PREDICTION, retrievability),
+					);
+					const wasRecalled = isRecalled(step.rating);
 
-			if (point.wasRecalled) {
-				totalLoss -= Math.log(clippedR);
-			} else {
-				totalLoss -= Math.log(1 - clippedR);
+					totalLoss -= wasRecalled ? Math.log(clipped) : Math.log(1 - clipped);
+					totalSquaredError += (retrievability - (wasRecalled ? 1 : 0)) ** 2;
+					predictionCount++;
+				}
+				state = algorithm.next_state(state, step.elapsedDays, step.rating);
 			}
-
-			const actual = point.wasRecalled ? 1 : 0;
-			totalSquaredError += (retrievability - actual) ** 2;
 		}
 
-		const n = Math.max(data.length, 1);
+		const n = Math.max(predictionCount, 1);
 		return {
-			logLoss: totalLoss / n,
+			avgLoss: totalLoss / n,
 			rmse: Math.sqrt(totalSquaredError / n),
+			predictionCount,
 		};
 	}
 
-	private clipWeight(value: number, index: number): number {
-		const ranges: [number, number][] = [
-			[0.01, 1.0],
-			[0.5, 5.0],
-			[1.0, 10.0],
-			[2.0, 20.0],
-			[1.0, 15.0],
-			[0.1, 2.0],
-			[0.5, 5.0],
-			[0.0001, 0.1],
-			[1.0, 5.0],
-			[0.01, 0.5],
-			[0.3, 2.0],
-			[0.5, 3.0],
-			[0.01, 0.3],
-			[0.1, 0.5],
-			[0.5, 3.0],
-			[0.3, 1.0],
-			[1.0, 3.0],
-			[0.1, 1.0],
-			[0.01, 0.3],
-			[0.01, 0.2],
-			[0.05, 0.5],
-		];
+	/**
+	 * Forward-difference gradients against the already-computed base loss.
+	 * When a parameter sits at its upper clip bound the probe flips backward
+	 * so the perturbed vector stays inside the valid region.
+	 */
+	private numericGradients(
+		weights: number[],
+		sequences: ReviewStep[][],
+		baseLoss: number,
+	): number[] {
+		const gradients = new Array<number>(weights.length).fill(0);
 
-		const range = ranges[index] ?? [0.001, 10.0];
-		return Math.max(range[0], Math.min(range[1], value));
+		for (let i = 0; i < weights.length; i++) {
+			const value = weights[i] ?? 0;
+			const epsilon = Math.max(1e-4, Math.abs(value) * 1e-3);
+
+			const probe = [...weights];
+			probe[i] = value + epsilon;
+			const clippedForward = clipParameters([...probe], 0);
+			if ((clippedForward[i] ?? 0) > value) {
+				probe[i] = clippedForward[i] ?? value;
+				const lossPlus = this.evaluate(probe, sequences).avgLoss;
+				gradients[i] = (lossPlus - baseLoss) / ((probe[i] ?? 0) - value);
+				continue;
+			}
+
+			probe[i] = value - epsilon;
+			const clippedBackward = clipParameters([...probe], 0);
+			if ((clippedBackward[i] ?? 0) < value) {
+				probe[i] = clippedBackward[i] ?? value;
+				const lossMinus = this.evaluate(probe, sequences).avgLoss;
+				gradients[i] = (baseLoss - lossMinus) / (value - (probe[i] ?? 0));
+			}
+		}
+
+		return gradients;
 	}
 
 	validateWeights(weights: number[]): boolean {
 		if (!Array.isArray(weights)) return false;
 		if (weights.length !== 21) return false;
 		return weights.every(
-			(w) => typeof w === "number" && Number.isFinite(w) && w > 0,
+			(w) => typeof w === "number" && Number.isFinite(w) && w >= 0,
 		);
 	}
 }

--- a/packages/core/src/metrics/fsrs-tools/scheduler/fuzz.ts
+++ b/packages/core/src/metrics/fsrs-tools/scheduler/fuzz.ts
@@ -1,0 +1,102 @@
+/**
+ * Anki-compatible fuzz math and deterministic weighted day selection.
+ *
+ * Ported from Anki's rslib/src/scheduler/states/fuzz.rs and
+ * load_balancer.rs so per-review balancing matches Anki behavior.
+ */
+
+interface FuzzRange {
+	start: number;
+	end: number;
+	factor: number;
+}
+
+const FUZZ_RANGES: FuzzRange[] = [
+	{ start: 2.5, end: 7.0, factor: 0.15 },
+	{ start: 7.0, end: 20.0, factor: 0.1 },
+	{ start: 20.0, end: Number.MAX_VALUE, factor: 0.05 },
+];
+
+/**
+ * Amount of fuzz applied to the interval in both directions: intervals
+ * under 2.5 days get none, longer ones get 1 day plus a factor of the days
+ * falling into each range.
+ */
+export function fuzzDelta(interval: number): number {
+	if (interval < 2.5) return 0;
+	return FUZZ_RANGES.reduce(
+		(delta, range) =>
+			delta +
+			range.factor * Math.max(0, Math.min(interval, range.end) - range.start),
+		1.0,
+	);
+}
+
+/**
+ * Bounds of the fuzz range around an interval, clamped to [minimum, maximum].
+ * Mirrors Anki's constrained_fuzz_bounds including the widen-by-one rule.
+ */
+export function constrainedFuzzBounds(
+	interval: number,
+	minimum: number,
+	maximum: number,
+): [number, number] {
+	const min = Math.min(minimum, maximum);
+	const clamped = Math.max(min, Math.min(interval, maximum));
+	const delta = fuzzDelta(clamped);
+
+	let lower = Math.round(clamped - delta);
+	let upper = Math.round(clamped + delta);
+
+	lower = Math.max(min, Math.min(lower, maximum));
+	upper = Math.max(min, Math.min(upper, maximum));
+
+	if (upper === lower && upper > 2 && upper < maximum) {
+		upper = lower + 1;
+	}
+
+	return [lower, upper];
+}
+
+/** FNV-1a string hash — stable seed source for deterministic balancing */
+export function hashString(input: string): number {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < input.length; i++) {
+		hash ^= input.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return hash >>> 0;
+}
+
+/** Small deterministic PRNG (mulberry32) — same seed, same sequence */
+export function mulberry32(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+export interface WeightedDay {
+	day: number;
+	weight: number;
+}
+
+/** Pick a day proportionally to its weight using the provided PRNG */
+export function selectWeightedDay(
+	days: WeightedDay[],
+	random: () => number,
+): number | null {
+	const total = days.reduce((sum, d) => sum + d.weight, 0);
+	if (total <= 0 || days.length === 0) return null;
+
+	let remaining = random() * total;
+	for (const { day, weight } of days) {
+		remaining -= weight;
+		if (remaining <= 0) return day;
+	}
+	return days[days.length - 1]?.day ?? null;
+}

--- a/packages/core/src/metrics/fsrs-tools/scheduler/load-balance.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/scheduler/load-balance.service.ts
@@ -4,7 +4,16 @@
  * Distributes reviews evenly across days to prevent workload spikes.
  */
 
+import { State } from "ts-fsrs";
+
 import { isEasyDay } from "./easy-days.service";
+import {
+	constrainedFuzzBounds,
+	hashString,
+	mulberry32,
+	selectWeightedDay,
+	type WeightedDay,
+} from "./fuzz";
 import type {
 	BalanceDueOptions,
 	BalanceDueResult,
@@ -16,35 +25,87 @@ import type {
 	WorkloadDistribution,
 } from "./scheduler.types";
 
+/** Range start that captures every overdue card regardless of age */
+const OVERDUE_RANGE_START = "1970-01-01";
+
+/** Horizon used to derive the automatic daily target from the real workload */
+const AUTO_TARGET_WINDOW_DAYS = 30;
+
+/** Anki: intervals beyond this are not worth balancing */
+const MAX_LOAD_BALANCE_INTERVAL = 90;
+
+/** Anki: near-zero weight that avoids zero-related corner cases */
+const EASY_DAYS_MINIMUM_LOAD = 0.0001;
+
 export class LoadBalanceService {
 	constructor(private cardStore: SchedulerCardStore) {}
 
+	/**
+	 * Average daily workload over the next AUTO_TARGET_WINDOW_DAYS, backlog
+	 * included, weighted so easy days count as a fraction of a normal day.
+	 * Used as the target when no manual target is configured.
+	 */
+	computeAutoTarget(
+		easyDays: NonNullable<LoadBalanceOptions["easyDays"]> = {
+			recurringDays: [],
+			specificDates: [],
+		},
+		easyDaysMultiplier = 0.5,
+		includeOverdue = true,
+	): number {
+		const today = new Date();
+		const endDate = new Date(today);
+		endDate.setDate(endDate.getDate() + AUTO_TARGET_WINDOW_DAYS);
+
+		const todayStr = this.formatDate(today);
+		const startDateStr = includeOverdue ? OVERDUE_RANGE_START : todayStr;
+		const totalCards = this.cardStore
+			.getDueCountsByDateRange(startDateStr, this.formatDate(endDate))
+			.reduce((sum, entry) => sum + entry.count, 0);
+
+		let weightedDays = 0;
+		const cursor = new Date(today);
+		while (cursor <= endDate) {
+			weightedDays += isEasyDay(cursor, easyDays) ? easyDaysMultiplier : 1;
+			cursor.setDate(cursor.getDate() + 1);
+		}
+
+		return Math.max(1, Math.round(totalCards / Math.max(1, weightedDays)));
+	}
+
 	balance(options: LoadBalanceOptions): SchedulingResult {
 		const {
-			targetPerDay,
 			maxDeviation,
 			days = 30,
 			easyDays = { recurringDays: [], specificDates: [] },
 			easyDaysMultiplier = 0.5,
+			includeOverdue = true,
+			cardIds,
+			completedToday = 0,
 			dryRun = true,
 		} = options;
+		const targetPerDay =
+			options.targetPerDay ??
+			this.computeAutoTarget(easyDays, easyDaysMultiplier, includeOverdue);
+		const movable = cardIds ? new Set(cardIds) : null;
 
 		const today = new Date();
 		const endDate = new Date(today);
 		endDate.setDate(endDate.getDate() + days);
 
-		const startDateStr = this.formatDate(today);
+		const todayStr = this.formatDate(today);
+		const startDateStr = includeOverdue ? OVERDUE_RANGE_START : todayStr;
 		const endDateStr = this.formatDate(endDate);
 
-		const dueCards = this.cardStore.getDueCardsByDateRange(
-			startDateStr,
-			endDateStr,
-		);
+		const dueCards = this.getReviewCards(startDateStr, endDateStr);
 
-		// Build distribution map
+		// Build distribution map. Overdue cards cannot be reviewed earlier than
+		// today, so they count toward today's bucket — an accumulated backlog
+		// becomes an overloaded "today" and is spread forward like any spike.
 		const distribution = new Map<string, CardDueInfo[]>();
 		for (const card of dueCards) {
-			const dateStr = this.formatDate(new Date(card.due));
+			const dueDateStr = this.formatDate(new Date(card.due));
+			const dateStr = dueDateStr < todayStr ? todayStr : dueDateStr;
 			const existing = distribution.get(dateStr) ?? [];
 			existing.push(card);
 			distribution.set(dateStr, existing);
@@ -56,9 +117,14 @@ export class LoadBalanceService {
 		while (currentDate <= endDate) {
 			const dateStr = this.formatDate(currentDate);
 			const isEasy = isEasyDay(currentDate, easyDays);
-			const target = isEasy
+			let target = isEasy
 				? Math.round(targetPerDay * easyDaysMultiplier)
 				: targetPerDay;
+			// Reviews already done today count toward today's workload — only
+			// the remaining capacity is available for the backlog spread.
+			if (dateStr === todayStr) {
+				target = Math.max(0, target - completedToday);
+			}
 			dailyTargets.set(dateStr, target);
 			currentDate.setDate(currentDate.getDate() + 1);
 		}
@@ -80,8 +146,24 @@ export class LoadBalanceService {
 			const threshold = target + maxDev;
 
 			if (cards.length > threshold) {
-				// This day is overloaded - move excess cards
-				const excess = cards.slice(Math.floor(threshold));
+				// Move the cards that tolerate a shift best: longest scheduled
+				// interval first, so short-interval (fragile) cards keep their day.
+				const byInterval = [...cards].sort(
+					(a, b) => a.scheduledDays - b.scheduledDays,
+				);
+				// Hysteresis: act only above threshold (target + deviation) but
+				// trim down to the target itself, so the deviation band stays
+				// free as slack — a day packed right at the ceiling would flag
+				// "needs balancing" again as soon as the average drifts down.
+				// With a movable subset, day capacity still counts every card but
+				// only subset cards may leave — move at most the day's excess.
+				const excessCount = cards.length - Math.floor(target);
+				const candidates = movable
+					? byInterval.filter((card) => movable.has(card.id))
+					: byInterval;
+				const excess = candidates.slice(
+					Math.max(0, candidates.length - excessCount),
+				);
 
 				for (const card of excess) {
 					// Find best day to move to
@@ -89,7 +171,7 @@ export class LoadBalanceService {
 						date,
 						distribution,
 						dailyTargets,
-						maxDev,
+						targetPerDay,
 						days,
 					);
 
@@ -139,131 +221,164 @@ export class LoadBalanceService {
 		};
 	}
 
+	/**
+	 * Per-review balancing, ported from Anki's load_balancer.rs: pick a day
+	 * within the interval's fuzz range by weighted random, preferring days
+	 * with fewer due cards and slightly earlier days, avoiding siblings and
+	 * respecting easy days. Deterministic per (card, target day) so the
+	 * rating-button preview matches the actual grade.
+	 */
 	balanceDue(options: BalanceDueOptions): BalanceDueResult {
 		const {
 			cardId,
 			originalDue,
-			targetPerDay,
-			maxDeviation,
 			maxShiftDays,
 			easyDays = { recurringDays: [], specificDates: [] },
 			easyDaysMultiplier = 0.5,
 		} = options;
 
-		if (maxShiftDays <= 0) {
-			return {
-				originalDue,
-				newDue: originalDue,
-				daysChanged: 0,
-				balanced: false,
-			};
+		const unbalanced: BalanceDueResult = {
+			originalDue,
+			newDue: originalDue,
+			daysChanged: 0,
+			balanced: false,
+		};
+		if (maxShiftDays <= 0) return unbalanced;
+
+		const todayStr = this.formatDate(new Date());
+		const originalDayStr = this.formatDate(new Date(originalDue));
+		const interval = this.daysDiff(todayStr, originalDayStr);
+
+		// Anki: intervals under 2.5 days get no fuzz, far-out ones no balancing
+		if (interval < 2.5 || interval > MAX_LOAD_BALANCE_INTERVAL) {
+			return unbalanced;
 		}
 
-		const originalDate = new Date(originalDue);
-		const today = new Date();
-		const tomorrow = new Date(today);
-		tomorrow.setDate(tomorrow.getDate() + 1);
-
-		const startDate = new Date(originalDate);
-		startDate.setDate(startDate.getDate() - maxShiftDays);
-		if (startDate < tomorrow) startDate.setTime(tomorrow.getTime());
-
-		const endDate = new Date(originalDate);
-		endDate.setDate(endDate.getDate() + maxShiftDays);
-
-		if (startDate > endDate) {
-			return {
-				originalDue,
-				newDue: originalDue,
-				daysChanged: 0,
-				balanced: false,
-			};
-		}
-
-		const distribution = this.getDistributionMap(
-			this.formatDate(startDate),
-			this.formatDate(endDate),
-			cardId,
+		const [fuzzLower, fuzzUpper] = constrainedFuzzBounds(
+			interval,
+			1,
+			interval + maxShiftDays,
 		);
-		const maxDev = targetPerDay * (maxDeviation / 100);
-		const originalDateStr = this.formatDate(originalDate);
+		const lower = Math.max(fuzzLower, interval - maxShiftDays, 1);
+		const upper = fuzzUpper;
+		if (upper <= lower) return unbalanced;
 
-		if (
-			this.hasRoom(
-				originalDateStr,
-				distribution,
-				targetPerDay,
-				maxDev,
-				easyDays,
-				easyDaysMultiplier,
-			)
-		) {
-			return {
-				originalDue,
-				newDue: originalDue,
-				daysChanged: 0,
-				balanced: false,
-			};
-		}
+		const countsByOffset = this.collectWindowCounts(
+			cardId,
+			todayStr,
+			lower,
+			upper,
+		);
 
-		let bestDate: string | null = null;
-		let bestScore = Infinity;
+		const offsets: number[] = [];
+		for (let offset = lower; offset <= upper; offset++) offsets.push(offset);
+		const counts = offsets.map((offset) => countsByOffset.get(offset) ?? 0);
+		const easyModifiers = this.calculateEasyDaysModifiers(
+			offsets,
+			counts,
+			easyDays,
+			easyDaysMultiplier,
+		);
 
-		const cursor = new Date(startDate);
-		while (cursor <= endDate) {
-			const dateStr = this.formatDate(cursor);
-			const daysChanged = this.daysDiff(originalDateStr, dateStr);
-			if (
-				daysChanged !== 0 &&
-				this.hasRoom(
-					dateStr,
-					distribution,
-					targetPerDay,
-					maxDev,
-					easyDays,
-					easyDaysMultiplier,
-				)
-			) {
-				const target = this.getTargetForDate(
-					cursor,
-					targetPerDay,
-					easyDays,
-					easyDaysMultiplier,
-				);
-				const count = distribution.get(dateStr) ?? 0;
-				const fillRatio = target > 0 ? count / target : count;
-				const score = Math.abs(daysChanged) * 4 + fillRatio;
-				if (score < bestScore) {
-					bestScore = score;
-					bestDate = dateStr;
-				}
-			}
-			cursor.setDate(cursor.getDate() + 1);
-		}
+		const weightedDays: WeightedDay[] = offsets.map((offset, i) => {
+			const count = counts[i] ?? 0;
+			// Anki: an empty day gets full weight, bypassing all modifiers
+			if (count === 0) return { day: offset, weight: 1.0 };
 
-		if (!bestDate) {
-			return {
-				originalDue,
-				newDue: originalDue,
-				daysChanged: 0,
-				balanced: false,
-			};
-		}
+			const countWeight = (1 / count) ** 2.15;
+			const intervalWeight = (1 / offset) ** 3;
+			const weight =
+				countWeight * intervalWeight * (easyModifiers[i] ?? 1.0);
+			return { day: offset, weight };
+		});
 
-		const newDue = this.withDate(originalDue, bestDate);
+		const random = mulberry32(hashString(`${cardId}:${originalDayStr}`));
+		const selected = selectWeightedDay(weightedDays, random);
+		if (selected === null || selected === interval) return unbalanced;
+
+		const newDue = this.withDate(originalDue, this.dateFromToday(selected));
 		return {
 			originalDue,
 			newDue,
-			daysChanged: this.daysDiff(originalDateStr, bestDate),
+			daysChanged: selected - interval,
 			balanced: true,
 		};
+	}
+
+	/**
+	 * Due counts per day-offset for the candidate window, via the aggregate
+	 * query (no row materialization) so grading stays fast on large vaults.
+	 */
+	private collectWindowCounts(
+		cardId: string,
+		todayStr: string,
+		lower: number,
+		upper: number,
+	): Map<number, number> {
+		const counts = this.cardStore.getDueCountsByDateRange(
+			this.dateFromToday(lower),
+			this.dateFromToday(upper),
+			cardId,
+		);
+		const countsByOffset = new Map<number, number>();
+		for (const { day, count } of counts) {
+			countsByOffset.set(this.daysDiff(todayStr, day), count);
+		}
+		return countsByOffset;
+	}
+
+	/**
+	 * Anki's easy-days gate generalized to a single multiplier m: normal days
+	 * stay on (1.0); easy days turn off (near-zero) when m is 0, or when the
+	 * day's m-normalized count exceeds its proportional share of the window.
+	 */
+	private calculateEasyDaysModifiers(
+		offsets: number[],
+		counts: number[],
+		easyDays: NonNullable<LoadBalanceOptions["easyDays"]>,
+		multiplier: number,
+	): number[] {
+		const isEasy = offsets.map((offset) =>
+			isEasyDay(new Date(this.dateFromToday(offset)), easyDays),
+		);
+		if (!isEasy.some(Boolean) || multiplier >= 1) {
+			return offsets.map(() => 1.0);
+		}
+
+		const totalCount = counts.reduce((sum, c) => sum + c, 0);
+		const totalPercents = isEasy.reduce(
+			(sum, easy) => sum + (easy ? multiplier : 1),
+			0,
+		);
+
+		return offsets.map((_offset, i) => {
+			if (!isEasy[i]) return 1.0;
+			if (multiplier <= EASY_DAYS_MINIMUM_LOAD) return EASY_DAYS_MINIMUM_LOAD;
+
+			const count = counts[i] ?? 0;
+			const otherDaysTotal = totalCount - count;
+			const otherPercents = totalPercents - multiplier;
+			if (otherPercents <= 0) return 1.0;
+
+			const normalizedCount = count / multiplier;
+			const reducedDayThreshold = otherDaysTotal / otherPercents;
+			return normalizedCount > reducedDayThreshold
+				? EASY_DAYS_MINIMUM_LOAD
+				: 1.0;
+		});
+	}
+
+	private dateFromToday(offset: number): string {
+		const date = new Date();
+		date.setDate(date.getDate() + offset);
+		return this.formatDate(date);
 	}
 
 	private findBestDay(
 		fromDate: string,
 		distribution: Map<string, CardDueInfo[]>,
 		targets: Map<string, number>,
-		maxDev: number,
+		defaultTarget: number,
 		maxDays: number,
 	): string | null {
 		let bestDate: string | null = null;
@@ -278,10 +393,11 @@ export class LoadBalanceService {
 			const dateStr = this.formatDate(candidateDate);
 
 			const currentCount = distribution.get(dateStr)?.length ?? 0;
-			const target = targets.get(dateStr) ?? 100;
-			const threshold = target + maxDev;
+			const target = targets.get(dateStr) ?? defaultTarget;
 
-			if (currentCount < threshold) {
+			// Destinations fill only up to the target — the deviation band is
+			// tolerance for future drift, not extra capacity to pack into.
+			if (currentCount < target) {
 				// Calculate score (prefer closer dates and emptier days)
 				const fillRatio = currentCount / target;
 				const score = offset * 0.5 + fillRatio * 10;
@@ -291,6 +407,10 @@ export class LoadBalanceService {
 					bestDate = dateStr;
 				}
 			}
+
+			// Distance alone puts every later day above the current best —
+			// no candidate past this offset can win, so stop scanning.
+			if (bestScore <= (offset + 1) * 0.5) break;
 		}
 
 		return bestDate;
@@ -304,49 +424,15 @@ export class LoadBalanceService {
 		return `${dateStr}T${originalDue.split("T")[1] ?? "00:00:00.000Z"}`;
 	}
 
-	private getDistributionMap(
-		startDate: string,
-		endDate: string,
-		excludeCardId?: string,
-	): Map<string, number> {
-		const cards = this.cardStore
+	/**
+	 * Due cards in range, minus New-state cards: new cards are introduced by
+	 * the daily new-card limit, not by due-date scheduling, so counting or
+	 * moving them would distort the balance.
+	 */
+	private getReviewCards(startDate: string, endDate: string): CardDueInfo[] {
+		return this.cardStore
 			.getDueCardsByDateRange(startDate, endDate)
-			.filter((card) => card.id !== excludeCardId);
-		const distribution = new Map<string, number>();
-		for (const card of cards) {
-			const dateStr = this.formatDate(new Date(card.due));
-			distribution.set(dateStr, (distribution.get(dateStr) ?? 0) + 1);
-		}
-		return distribution;
-	}
-
-	private getTargetForDate(
-		date: Date,
-		targetPerDay: number,
-		easyDays: NonNullable<LoadBalanceOptions["easyDays"]>,
-		easyDaysMultiplier: number,
-	): number {
-		return isEasyDay(date, easyDays)
-			? Math.round(targetPerDay * easyDaysMultiplier)
-			: targetPerDay;
-	}
-
-	private hasRoom(
-		dateStr: string,
-		distribution: Map<string, number>,
-		targetPerDay: number,
-		maxDev: number,
-		easyDays: NonNullable<LoadBalanceOptions["easyDays"]>,
-		easyDaysMultiplier: number,
-	): boolean {
-		const target = this.getTargetForDate(
-			new Date(dateStr),
-			targetPerDay,
-			easyDays,
-			easyDaysMultiplier,
-		);
-		const threshold = target + maxDev;
-		return (distribution.get(dateStr) ?? 0) < threshold;
+			.filter((card) => card.state !== State.New);
 	}
 
 	private daysDiff(from: string, to: string): number {

--- a/packages/core/src/metrics/fsrs-tools/scheduler/scheduler.types.ts
+++ b/packages/core/src/metrics/fsrs-tools/scheduler/scheduler.types.ts
@@ -7,6 +7,7 @@ export interface CardDueInfo {
 	due: string;
 	scheduledDays: number;
 	sourceUid?: string;
+	state?: State;
 }
 
 export interface SchedulerCardData extends CardDueInfo {
@@ -17,10 +18,26 @@ export interface SchedulerCardData extends CardDueInfo {
 	buriedUntil?: string;
 }
 
+/** Count of Review-state due cards on one UTC day (YYYY-MM-DD) */
+export interface DueDayCount {
+	day: string;
+	count: number;
+}
+
 export interface SchedulerCardStore {
 	get(cardId: string): SchedulerCardData | undefined;
 	getCards(): SchedulerCardData[];
 	getDueCardsByDateRange(startDate: string, endDate: string): CardDueInfo[];
+	/**
+	 * Aggregate variant of getDueCardsByDateRange for workload histograms:
+	 * counts Review-state cards per UTC due day without materializing rows,
+	 * so per-review hot paths can afford it.
+	 */
+	getDueCountsByDateRange(
+		startDate: string,
+		endDate: string,
+		excludeCardId?: string,
+	): DueDayCount[];
 	updateCardDue(cardId: string, newDue: string): void;
 	updateCardScheduling(
 		cardId: string,
@@ -48,19 +65,25 @@ export interface CardScheduleChange {
 }
 
 export interface LoadBalanceOptions {
-	targetPerDay: number;
+	/** Daily review target; omit to derive it from the forecast average */
+	targetPerDay?: number;
 	maxDeviation: number;
 	days?: number;
 	easyDays?: EasyDaysConfig;
 	easyDaysMultiplier?: number;
+	/** Treat overdue cards as due today and spread the backlog forward (default true) */
+	includeOverdue?: boolean;
+	/** Restrict which cards may be moved (e.g. one project); day capacity still counts all cards */
+	cardIds?: string[];
+	/** Reviews already done today — subtracted from today's remaining capacity */
+	completedToday?: number;
 	dryRun?: boolean;
 }
 
 export interface BalanceDueOptions {
 	cardId: string;
 	originalDue: string;
-	targetPerDay: number;
-	maxDeviation: number;
+	/** Hard cap on the day shift; 0 disables per-review balancing */
 	maxShiftDays: number;
 	easyDays?: EasyDaysConfig;
 	easyDaysMultiplier?: number;

--- a/packages/core/src/metrics/fsrs-tools/statistics/workload-forecast.calculator.ts
+++ b/packages/core/src/metrics/fsrs-tools/statistics/workload-forecast.calculator.ts
@@ -84,6 +84,7 @@ export class WorkloadForecastCalculator {
 	getForecast(
 		days: number = 30,
 		excludeSourceUids?: ReadonlySet<string>,
+		includeSourceUids?: ReadonlySet<string>,
 	): WorkloadForecastEntry[] {
 		const today = new Date();
 		const endDate = new Date(today);
@@ -97,7 +98,8 @@ export class WorkloadForecastCalculator {
 					(!c.buriedUntil || new Date(c.buriedUntil) <= today) &&
 					new Date(c.due) >= today &&
 					new Date(c.due) <= endDate &&
-					(!excludeSourceUids || !excludeSourceUids.has(c.sourceUid ?? "")),
+					(!excludeSourceUids || !excludeSourceUids.has(c.sourceUid ?? "")) &&
+					(!includeSourceUids || includeSourceUids.has(c.sourceUid ?? "")),
 			);
 
 		// Build forecast by date
@@ -145,8 +147,9 @@ export class WorkloadForecastCalculator {
 		days: number = 30,
 		excludeSourceUids?: ReadonlySet<string>,
 		maxDeviation: number = 20,
+		includeSourceUids?: ReadonlySet<string>,
 	): WorkloadForecastSummary {
-		const forecast = this.getForecast(days, excludeSourceUids);
+		const forecast = this.getForecast(days, excludeSourceUids, includeSourceUids);
 
 		if (forecast.length === 0) {
 			return {
@@ -216,8 +219,9 @@ export class WorkloadForecastCalculator {
 	getWorkloadByDayOfWeek(
 		days: number = 30,
 		excludeSourceUids?: ReadonlySet<string>,
+		includeSourceUids?: ReadonlySet<string>,
 	): { day: number; dayName: string; avgCount: number }[] {
-		const forecast = this.getForecast(days, excludeSourceUids);
+		const forecast = this.getForecast(days, excludeSourceUids, includeSourceUids);
 
 		// Group by day of week
 		const byDay = new Map<number, number[]>();

--- a/packages/core/src/persistence/sqlite/SqliteStoreService.ts
+++ b/packages/core/src/persistence/sqlite/SqliteStoreService.ts
@@ -522,6 +522,18 @@ export class SqliteStoreService {
 		return this.cards.getDueCardsByDateRange(startDate, endDate);
 	}
 
+	getDueCountsByDateRange(
+		startDate: string,
+		endDate: string,
+		excludeCardId?: string,
+	): { day: string; count: number }[] {
+		return this.cards.getDueCountsByDateRange(
+			startDate,
+			endDate,
+			excludeCardId,
+		);
+	}
+
 	updateCardDue(cardId: string, newDue: string): void {
 		this.cards.updateCardDue(cardId, newDue);
 	}

--- a/packages/core/src/persistence/sqlite/modules/CardActions.ts
+++ b/packages/core/src/persistence/sqlite/modules/CardActions.ts
@@ -73,6 +73,18 @@ export class CardActions {
 		return this.queries.getDueCardsByDateRange(startDate, endDate);
 	}
 
+	getDueCountsByDateRange(
+		startDate: string,
+		endDate: string,
+		excludeCardId?: string,
+	): { day: string; count: number }[] {
+		return this.queries.getDueCountsByDateRange(
+			startDate,
+			endDate,
+			excludeCardId,
+		);
+	}
+
 	browserQuery(
 		where: string,
 		params: (string | number)[],

--- a/packages/core/src/persistence/sqlite/modules/cards/card-query-actions.ts
+++ b/packages/core/src/persistence/sqlite/modules/cards/card-query-actions.ts
@@ -134,6 +134,37 @@ export class CardQueryActions {
 		return rows.map(mapRow);
 	}
 
+	/**
+	 * Count of active Review-state cards per UTC due day within
+	 * [startDate, endDate]. New cards are excluded: they enter the schedule
+	 * via the daily new-card limit, not due-date scheduling. Aggregates in
+	 * SQL (no notes JOIN, no row materialization) so it is cheap enough for
+	 * per-review load-balancing paths.
+	 */
+	getDueCountsByDateRange(
+		startDate: string,
+		endDate: string,
+		excludeCardId?: string,
+	): { day: string; count: number }[] {
+		const excludeClause = excludeCardId ? "AND c.id != ?" : "";
+		const params = excludeCardId
+			? [startDate, endDate, excludeCardId]
+			: [startDate, endDate];
+		return this.db.query<{ day: string; count: number }>(
+			`SELECT date(c.due) AS day, COUNT(*) AS count
+                 FROM cards c
+                 WHERE c.deleted_at IS NULL
+                   AND c.suspended = 0
+                   AND (c.buried_until IS NULL OR c.buried_until <= datetime('now'))
+                   AND c.state = 2
+                   AND date(c.due) BETWEEN ? AND ?
+                   ${excludeClause}
+                 GROUP BY day
+                 ORDER BY day ASC`,
+			params,
+		);
+	}
+
 	browserQuery(
 		where: string,
 		params: (string | number)[],

--- a/packages/core/src/types/settings.types.ts
+++ b/packages/core/src/types/settings.types.ts
@@ -290,7 +290,9 @@ export interface TrueRecallSettings {
 
 	/** Enable automatic load balancing when scheduling */
 	loadBalanceEnabled: boolean;
-	/** Target daily review count for load balancing */
+	/** How the daily target is determined: computed from the forecast average or set manually */
+	loadBalanceTargetMode: "auto" | "manual";
+	/** Target daily review count for load balancing (manual mode only) */
 	loadBalanceTarget: number;
 	/** Maximum deviation from target (percentage 0-100) */
 	loadBalanceMaxDeviation: number;

--- a/packages/core/tests/persistence/sqlite/card-actions.due-counts.test.ts
+++ b/packages/core/tests/persistence/sqlite/card-actions.due-counts.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for CardActions.getDueCountsByDateRange
+ *
+ * Aggregate due-count histogram used by load balancing hot paths.
+ * Counts Review-state cards per UTC due day without materializing
+ * full card rows (no notes/note_types JOIN).
+ */
+import { State } from "ts-fsrs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	createTestCard,
+	createTestContext,
+	insertCardDirect,
+	type TestContext,
+} from "./__setup__/test-database";
+
+describe("CardActions - getDueCountsByDateRange", () => {
+	let ctx: TestContext;
+
+	beforeEach(async () => {
+		ctx = await createTestContext();
+	});
+
+	afterEach(() => {
+		ctx.close();
+	});
+
+	it("counts only active Review-state cards, grouped by UTC due day", () => {
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "review-a",
+				state: State.Review,
+				due: "2026-07-20T08:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "review-b",
+				state: State.Review,
+				due: "2026-07-20T22:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "review-c",
+				state: State.Review,
+				due: "2026-07-21T10:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "new-card",
+				state: State.New,
+				due: "2026-07-20T10:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "learning-card",
+				state: State.Learning,
+				due: "2026-07-20T10:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "suspended-card",
+				state: State.Review,
+				due: "2026-07-20T10:00:00.000Z",
+				suspended: true,
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "buried-card",
+				state: State.Review,
+				due: "2026-07-20T10:00:00.000Z",
+				buriedUntil: "2099-01-01T00:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "out-of-range",
+				state: State.Review,
+				due: "2026-08-05T10:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "deleted-card",
+				state: State.Review,
+				due: "2026-07-20T10:00:00.000Z",
+			}),
+		);
+		ctx.db.run(`UPDATE cards SET deleted_at = ? WHERE id = ?`, [
+			Date.now(),
+			"deleted-card",
+		]);
+
+		const counts = ctx.cards.getDueCountsByDateRange(
+			"2026-07-19",
+			"2026-07-25",
+		);
+
+		expect(counts).toEqual([
+			{ day: "2026-07-20", count: 2 },
+			{ day: "2026-07-21", count: 1 },
+		]);
+	});
+
+	it("counts a formerly buried card once its buried_until has passed", () => {
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "unburied-card",
+				state: State.Review,
+				due: "2026-07-20T10:00:00.000Z",
+				buriedUntil: "2000-01-01T00:00:00.000Z",
+			}),
+		);
+
+		const counts = ctx.cards.getDueCountsByDateRange(
+			"2026-07-19",
+			"2026-07-25",
+		);
+
+		expect(counts).toEqual([{ day: "2026-07-20", count: 1 }]);
+	});
+
+	it("excludes the given card id from the counts", () => {
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "kept-card",
+				state: State.Review,
+				due: "2026-07-20T08:00:00.000Z",
+			}),
+		);
+		insertCardDirect(
+			ctx.cards,
+			createTestCard({
+				id: "excluded-card",
+				state: State.Review,
+				due: "2026-07-20T09:00:00.000Z",
+			}),
+		);
+
+		const counts = ctx.cards.getDueCountsByDateRange(
+			"2026-07-19",
+			"2026-07-25",
+			"excluded-card",
+		);
+
+		expect(counts).toEqual([{ day: "2026-07-20", count: 1 }]);
+	});
+
+	it("returns an empty array when no cards match the range", () => {
+		const counts = ctx.cards.getDueCountsByDateRange(
+			"2026-07-19",
+			"2026-07-25",
+		);
+
+		expect(counts).toEqual([]);
+	});
+});

--- a/packages/core/tests/services/fsrs-helper/fsrs-helper.service.test.ts
+++ b/packages/core/tests/services/fsrs-helper/fsrs-helper.service.test.ts
@@ -22,6 +22,7 @@ describe("FSRSHelperService", () => {
 		});
 		const helper = new FSRSHelperService(store as never, {
 			...DEFAULT_SETTINGS,
+			loadBalanceTargetMode: "manual",
 			loadBalanceTarget: 10,
 			loadBalanceMaxDeviation: 20,
 		});
@@ -41,6 +42,7 @@ describe("FSRSHelperService", () => {
 		});
 		const helper = new FSRSHelperService(store as never, {
 			...DEFAULT_SETTINGS,
+			loadBalanceTargetMode: "manual",
 			loadBalanceTarget: 10,
 			loadBalanceMaxDeviation: 20,
 		});
@@ -141,6 +143,21 @@ function createStore({
 	return {
 		getCards: vi.fn(() => allCards),
 		getDueCardsByDateRange: vi.fn(() => balanceCards),
+		getDueCountsByDateRange: vi.fn(
+			(startDate: string, endDate: string, excludeCardId?: string) => {
+				const counts = new Map<string, number>();
+				for (const card of balanceCards) {
+					if (card.state === State.New || card.id === excludeCardId) continue;
+					const day = card.due.split("T")[0] ?? "";
+					if (day < startDate || day > endDate) continue;
+					counts.set(day, (counts.get(day) ?? 0) + 1);
+				}
+				return Array.from(counts.entries())
+					.map(([day, count]) => ({ day, count }))
+					.sort((a, b) => a.day.localeCompare(b.day));
+			},
+		),
 		updateCardDue: vi.fn(),
+		stats: { getDailyStats: vi.fn(() => null) },
 	};
 }

--- a/packages/core/tests/services/fsrs-helper/mocks/scheduler.mocks.ts
+++ b/packages/core/tests/services/fsrs-helper/mocks/scheduler.mocks.ts
@@ -1,10 +1,12 @@
 /**
  * Mock factories for FSRS Helper scheduler service tests
  */
+import { State } from "ts-fsrs";
 import { type Mock, vi } from "vitest";
 
 import type {
 	CardDueInfo,
+	DueDayCount,
 	SchedulerCardData,
 	SchedulerCardStore,
 	WorkloadDistribution,
@@ -22,6 +24,10 @@ export interface MockSchedulerCardStore extends SchedulerCardStore {
 		[startDate: string, endDate: string],
 		CardDueInfo[]
 	>;
+	getDueCountsByDateRange: Mock<
+		[startDate: string, endDate: string, excludeCardId?: string],
+		DueDayCount[]
+	>;
 	updateCardDue: Mock<[cardId: string, newDue: string], Promise<void>>;
 	updateCardScheduling: Mock<
 		[cardId: string, data: { due: string; scheduledDays: number }],
@@ -32,14 +38,40 @@ export interface MockSchedulerCardStore extends SchedulerCardStore {
 /**
  * Create a mock SchedulerCardStore for scheduler tests.
  * Returns a properly typed mock that satisfies the SchedulerCardStore interface.
+ *
+ * getDueCountsByDateRange derives its counts from whatever
+ * getDueCardsByDateRange returns, mirroring the production SQL semantics
+ * (Review cards only, range-filtered by UTC due day, optional exclusion).
+ * Tests that stub getDueCardsByDateRange get matching counts for free.
  */
 export function createMockCardStore(
 	cards: CardDueInfo[] = [],
 ): MockSchedulerCardStore {
+	const getDueCardsByDateRange = vi
+		.fn<[string, string], CardDueInfo[]>()
+		.mockReturnValue(cards);
+
+	const getDueCountsByDateRange = vi
+		.fn<[string, string, string?], DueDayCount[]>()
+		.mockImplementation(
+			(startDate: string, endDate: string, excludeCardId?: string) => {
+				const counts = new Map<string, number>();
+				for (const card of getDueCardsByDateRange(startDate, endDate)) {
+					if (card.state === State.New) continue;
+					if (card.id === excludeCardId) continue;
+					const day = card.due.split("T")[0] ?? "";
+					if (day < startDate || day > endDate) continue;
+					counts.set(day, (counts.get(day) ?? 0) + 1);
+				}
+				return Array.from(counts.entries())
+					.map(([day, count]) => ({ day, count }))
+					.sort((a, b) => a.day.localeCompare(b.day));
+			},
+		);
+
 	return {
-		getDueCardsByDateRange: vi
-			.fn<[string, string], CardDueInfo[]>()
-			.mockReturnValue(cards),
+		getDueCardsByDateRange,
+		getDueCountsByDateRange,
 		updateCardDue: vi
 			.fn<[string, string], Promise<void>>()
 			.mockResolvedValue(undefined),

--- a/packages/core/tests/services/fsrs-helper/optimizer/parameter-optimizer.service.test.ts
+++ b/packages/core/tests/services/fsrs-helper/optimizer/parameter-optimizer.service.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Replay-based FSRS optimizer tests.
+ *
+ * Synthetic review histories are generated with ts-fsrs itself using a
+ * "true" weight vector different from the training start, so a working
+ * optimizer must move multiple parameters — the historical failure mode
+ * was a loss in which only the decay parameter (w20) had a gradient.
+ */
+import {
+	default_w,
+	FSRSAlgorithm,
+	clipParameters,
+	generatorParameters,
+	Rating,
+	State,
+} from "ts-fsrs";
+import { describe, expect, it } from "vitest";
+
+import {
+	isRecalled,
+	ParameterOptimizerService,
+} from "../../../../src/metrics/fsrs-tools/optimizer/parameter-optimizer.service";
+import type { OptimizationReviewEntry } from "../../../../src/metrics/fsrs-tools/optimizer/optimizer.types";
+import {
+	hashString,
+	mulberry32,
+} from "../../../../src/metrics/fsrs-tools/scheduler/fuzz";
+import type { Grade } from "../../../../src/types";
+
+function generateReviews(
+	trueWeights: number[],
+	cards: number,
+	reviewsPerCard: number,
+): OptimizationReviewEntry[] {
+	const algorithm = new FSRSAlgorithm(
+		generatorParameters({ w: trueWeights, enable_short_term: true }),
+	);
+	const entries: OptimizationReviewEntry[] = [];
+
+	for (let c = 0; c < cards; c++) {
+		let state: { stability: number; difficulty: number } | null = null;
+		let reviewedAt = 1_700_000_000_000 + c;
+
+		for (let r = 0; r < reviewsPerCard; r++) {
+			const elapsedDays = state ? Math.max(1, Math.round(state.stability)) : 0;
+			reviewedAt += elapsedDays * 86_400_000;
+
+			let rating: Grade;
+			if (!state) {
+				rating = Rating.Good as Grade;
+			} else {
+				const retrievability = algorithm.forgetting_curve(
+					elapsedDays,
+					state.stability,
+				);
+				const roll = mulberry32(hashString(`${c}:${r}`))();
+				rating = (roll < retrievability ? Rating.Good : Rating.Again) as Grade;
+			}
+
+			entries.push({
+				cardId: `card-${c}`,
+				reviewedAt,
+				rating,
+				scheduledDays: elapsedDays,
+				elapsedDays,
+				state: State.Review,
+				stability: state?.stability ?? 0,
+				difficulty: state?.difficulty ?? 0,
+			});
+			state = algorithm.next_state(state, elapsedDays, rating);
+		}
+	}
+
+	return entries;
+}
+
+describe("ParameterOptimizerService (replay-based)", () => {
+	it("returns insufficient_data below the review threshold", async () => {
+		const service = new ParameterOptimizerService();
+		const reviews = generateReviews([...default_w], 10, 3);
+
+		const result = await service.optimize({
+			reviews,
+			currentWeights: [...default_w],
+		});
+
+		expect(result.metrics.convergenceStatus).toBe("insufficient_data");
+		expect(result.weights).toEqual([...default_w]);
+	});
+
+	it("improves the loss and moves more than just the decay parameter", async () => {
+		const service = new ParameterOptimizerService();
+		// True model has much stronger initial stabilities than the defaults
+		const trueWeights = [...default_w];
+		trueWeights[0] = 1.5;
+		trueWeights[1] = 4.0;
+		trueWeights[2] = 8.0;
+		trueWeights[3] = 16.0;
+		const reviews = generateReviews(trueWeights, 120, 4);
+
+		const result = await service.optimize({
+			reviews,
+			currentWeights: [...default_w],
+		});
+
+		expect(result.improvement ?? 0).toBeGreaterThan(0);
+		expect(["converged", "max_iterations"]).toContain(
+			result.metrics.convergenceStatus,
+		);
+
+		const movedParams = result.weights.filter(
+			(w, i) => Math.abs(w - (default_w[i] ?? 0)) > 1e-6,
+		);
+		expect(movedParams.length).toBeGreaterThan(1);
+	}, 120_000);
+
+	it("returns weights inside the valid FSRS parameter bounds", async () => {
+		const service = new ParameterOptimizerService();
+		const reviews = generateReviews([...default_w], 110, 4);
+
+		const result = await service.optimize({
+			reviews,
+			currentWeights: [...default_w],
+		});
+
+		expect(clipParameters([...result.weights], 0)).toEqual(result.weights);
+	}, 120_000);
+
+	it("stops promptly when aborted", async () => {
+		const service = new ParameterOptimizerService();
+		const reviews = generateReviews([...default_w], 110, 4);
+		const controller = new AbortController();
+		let progressCalls = 0;
+
+		const promise = service.optimize(
+			{ reviews, currentWeights: [...default_w] },
+			{
+				abortSignal: controller.signal,
+				onProgress: () => {
+					progressCalls++;
+					controller.abort();
+				},
+			},
+		);
+		const result = await promise;
+
+		expect(progressCalls).toBeLessThanOrEqual(2);
+		expect(result.weights).toHaveLength(21);
+	}, 120_000);
+
+	it("counts Hard as a successful recall and Again as a lapse", () => {
+		expect(isRecalled(Rating.Hard as Grade)).toBe(true);
+		expect(isRecalled(Rating.Good as Grade)).toBe(true);
+		expect(isRecalled(Rating.Easy as Grade)).toBe(true);
+		expect(isRecalled(Rating.Again as Grade)).toBe(false);
+	});
+
+	it("validates weight vectors", () => {
+		const service = new ParameterOptimizerService();
+		expect(service.validateWeights([...default_w])).toBe(true);
+		expect(service.validateWeights([...default_w].slice(0, 19))).toBe(false);
+		expect(service.validateWeights([])).toBe(false);
+	});
+});

--- a/packages/core/tests/services/fsrs-helper/scheduler/fuzz.test.ts
+++ b/packages/core/tests/services/fsrs-helper/scheduler/fuzz.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Fuzz math tests — cases mirror Anki's rslib fuzz.rs test table so our
+ * bounds behave identically.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+	constrainedFuzzBounds,
+	fuzzDelta,
+	hashString,
+	mulberry32,
+	selectWeightedDay,
+} from "../../../../src/metrics/fsrs-tools/scheduler/fuzz";
+
+describe("fuzzDelta", () => {
+	it("applies no fuzz below 2.5 days", () => {
+		expect(fuzzDelta(1)).toBe(0);
+		expect(fuzzDelta(2.49)).toBe(0);
+	});
+
+	it("grows piecewise with the interval", () => {
+		expect(fuzzDelta(2.5)).toBeCloseTo(1.0, 5);
+		expect(fuzzDelta(7)).toBeCloseTo(1.675, 5);
+		expect(fuzzDelta(17)).toBeCloseTo(2.675, 5);
+		expect(fuzzDelta(37)).toBeCloseTo(3.825, 5);
+	});
+});
+
+describe("constrainedFuzzBounds", () => {
+	it.each([
+		["interval 2.5", 2.5, 1, 1000, 2, 4],
+		["interval 7", 7, 1, 1000, 5, 9],
+		["interval 17", 17, 3, 1000, 14, 20],
+		["interval 37", 37, 3, 1000, 33, 41],
+		["no fuzz under 2.5", 2.49, 1, 1000, 2, 2],
+		["clamped to raised minimum", 100, 101, 1000, 101, 108],
+		["clamped to lowered maximum", 100, 1, 99, 92, 99],
+		["clamped on both sides", 100, 97, 103, 97, 103],
+		["widened by one above minimum", 2.0, 3, 1000, 3, 4],
+		["not widened when maximum blocks it", 2.0, 3, 3, 3, 3],
+	])("%s", (_name, interval, min, max, lower, upper) => {
+		expect(constrainedFuzzBounds(interval, min, max)).toEqual([lower, upper]);
+	});
+});
+
+describe("deterministic selection", () => {
+	it("hashString is stable for the same input", () => {
+		expect(hashString("card-1:2026-02-05")).toBe(
+			hashString("card-1:2026-02-05"),
+		);
+		expect(hashString("card-1")).not.toBe(hashString("card-2"));
+	});
+
+	it("mulberry32 yields the same sequence for the same seed", () => {
+		const a = mulberry32(42);
+		const b = mulberry32(42);
+		expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+	});
+
+	it("selectWeightedDay picks proportionally to weights", () => {
+		const random = mulberry32(hashString("seed"));
+		const picks = new Map<number, number>();
+		for (let i = 0; i < 1000; i++) {
+			const day = selectWeightedDay(
+				[
+					{ day: 1, weight: 1 },
+					{ day: 2, weight: 0.000001 },
+				],
+				random,
+			);
+			if (day !== null) picks.set(day, (picks.get(day) ?? 0) + 1);
+		}
+		expect(picks.get(1) ?? 0).toBeGreaterThan(990);
+	});
+
+	it("selectWeightedDay returns null for empty or zero-weight input", () => {
+		const random = mulberry32(1);
+		expect(selectWeightedDay([], random)).toBeNull();
+		expect(selectWeightedDay([{ day: 1, weight: 0 }], random)).toBeNull();
+	});
+});

--- a/packages/core/tests/services/fsrs-helper/scheduler/load-balance.service.edge-cases.test.ts
+++ b/packages/core/tests/services/fsrs-helper/scheduler/load-balance.service.edge-cases.test.ts
@@ -46,7 +46,7 @@ describe("LoadBalanceService - Edge Cases", () => {
 		});
 
 		it("should move cards when count is threshold + 1", async () => {
-			// 13 cards on threshold of 12 = 1 card to move
+			// 13 cards exceed threshold 12 → the day trims to target 10 = 3 moves
 			const cards = createCardsOnDate("2026-02-01", 13);
 			mockStore = createMockCardStore(cards);
 			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
@@ -58,7 +58,7 @@ describe("LoadBalanceService - Edge Cases", () => {
 				dryRun: true,
 			});
 
-			expect(result.affectedCount).toBe(1);
+			expect(result.affectedCount).toBe(3);
 		});
 
 		it("should handle small target with deviation rounding", async () => {
@@ -75,7 +75,7 @@ describe("LoadBalanceService - Edge Cases", () => {
 				dryRun: true,
 			});
 
-			// threshold = 2 + (2 * 0.1) = 2.2, so 3 > 2.2 = 1 card moves
+			// threshold = 2.2 triggers, day trims to target 2 → 1 card moves
 			expect(result.affectedCount).toBe(1);
 		});
 
@@ -115,10 +115,10 @@ describe("LoadBalanceService - Edge Cases", () => {
 				dryRun: true,
 			});
 
-			// Day 1: 15 - 12 = 3 excess
-			// Day 3: 18 - 12 = 6 excess
-			// Total = 9 cards to move
-			expect(result.affectedCount).toBe(9);
+			// Day 1: 15 - 10 = 5 excess (trimmed to target)
+			// Day 3: 18 - 10 = 8 excess
+			// Total = 13 cards to move
+			expect(result.affectedCount).toBe(13);
 		});
 
 		it("should handle consecutive overloaded days", async () => {
@@ -138,8 +138,8 @@ describe("LoadBalanceService - Edge Cases", () => {
 				dryRun: true,
 			});
 
-			// Each overloaded day has 3 excess = 9 total
-			expect(result.affectedCount).toBe(9);
+			// Each overloaded day trims from 15 to target 10 = 15 total
+			expect(result.affectedCount).toBe(15);
 		});
 
 		it("should not create infinite loop when redistribution fills target day", async () => {
@@ -160,9 +160,9 @@ describe("LoadBalanceService - Edge Cases", () => {
 				dryRun: true,
 			});
 
-			// Day 1 has 13, threshold is 12, only 1 to move
-			// Should move to days that have room under 12
-			expect(result.affectedCount).toBe(1);
+			// Day 1 has 13 > threshold 12 → trims to target 10 (3 moves);
+			// days 2-3 sit at 11, inside the deviation band → untouched
+			expect(result.affectedCount).toBe(3);
 		});
 	});
 

--- a/packages/core/tests/services/fsrs-helper/scheduler/load-balance.service.test.ts
+++ b/packages/core/tests/services/fsrs-helper/scheduler/load-balance.service.test.ts
@@ -5,10 +5,13 @@
  * database query level (getDueCardsByDateRange excludes state IN (1, 3)).
  * This ensures learning cards with short intervals (minutes) are not moved to
  * days in the future, which would break FSRS's learning algorithm.
+ * New-state cards pass the query but are filtered inside the service — they
+ * are introduced by the daily new-card limit, not by due-date scheduling.
  *
  * The tests below use mock data that represents the filtered result (only
  * Review and New cards), as that's what the service receives in production.
  */
+import { State } from "ts-fsrs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LoadBalanceService } from "../../../../src/metrics/fsrs-tools/scheduler/load-balance.service";
@@ -55,9 +58,9 @@ describe("LoadBalanceService", () => {
 			expect(result.changes).toHaveLength(0);
 		});
 
-		it("moves cards from overloaded days", async () => {
-			// Day 1 has 15 cards, target 10, deviation 20% (threshold = 12)
-			// Should move 3 cards (15 - 12 = 3)
+		it("moves cards from overloaded days down to the target", async () => {
+			// Day 1 has 15 cards, target 10, deviation 20% (threshold = 12).
+			// 15 > 12 triggers balancing, which trims to the target: 5 moves.
 			const cards = [
 				...createCardsOnDate("2026-02-01", 15),
 				...createCardsOnDate("2026-02-02", 5),
@@ -72,8 +75,8 @@ describe("LoadBalanceService", () => {
 				dryRun: true,
 			});
 
-			expect(result.affectedCount).toBe(3);
-			expect(result.changes).toHaveLength(3);
+			expect(result.affectedCount).toBe(5);
+			expect(result.changes).toHaveLength(5);
 		});
 
 		it("respects maxDeviation threshold", async () => {
@@ -137,8 +140,8 @@ describe("LoadBalanceService", () => {
 				dryRun: true,
 			});
 
-			// 10 cards on easy day with threshold 7 = 3 excess
-			expect(result.affectedCount).toBe(3);
+			// 10 cards on easy day: threshold 7 triggers, trims to easy target 5
+			expect(result.affectedCount).toBe(5);
 		});
 
 		it("applies changes when dryRun is false", async () => {
@@ -226,18 +229,281 @@ describe("LoadBalanceService", () => {
 		});
 	});
 
-	describe("balanceDue", () => {
-		it("keeps original due date when target day has room", () => {
-			const cards = createCardsOnDate("2026-02-05", 5);
+	describe("balance with overdue backlog", () => {
+		it("buckets overdue cards as today and spreads the excess forward", async () => {
+			// 20 cards a week overdue, target 10, deviation 20% (threshold = 12)
+			const cards = createCardsOnDate("2026-01-25", 20);
 			mockStore = createMockCardStore(cards);
 			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
 			service = new LoadBalanceService(mockStore);
 
+			const result = await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20,
+				dryRun: true,
+			});
+
+			expect(result.affectedCount).toBe(10);
+			result.changes.forEach((change) => {
+				const newDate = change.newDue.split("T")[0] ?? "";
+				expect(newDate > "2026-02-01").toBe(true);
+			});
+		});
+
+		it("counts overdue and today's cards as one bucket", async () => {
+			const cards = [
+				...createCardsOnDate("2026-01-28", 8), // overdue
+				...createCardsOnDate("2026-02-01", 8), // due today
+			];
+			mockStore = createMockCardStore(cards);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+			service = new LoadBalanceService(mockStore);
+
+			const result = await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20, // threshold 12 triggers; bucket 16 trims to 10
+				dryRun: true,
+			});
+
+			expect(result.affectedCount).toBe(6);
+		});
+
+		it("queries the full past range by default", async () => {
+			mockStore.getDueCardsByDateRange.mockReturnValue([]);
+
+			await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20,
+				dryRun: true,
+			});
+
+			expect(mockStore.getDueCardsByDateRange).toHaveBeenCalledWith(
+				"1970-01-01",
+				"2026-03-03",
+			);
+		});
+
+		it("queries from today when includeOverdue is false", async () => {
+			mockStore.getDueCardsByDateRange.mockReturnValue([]);
+
+			await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20,
+				includeOverdue: false,
+				dryRun: true,
+			});
+
+			expect(mockStore.getDueCardsByDateRange).toHaveBeenCalledWith(
+				"2026-02-01",
+				"2026-03-03",
+			);
+		});
+
+		it("subtracts reviews already done today from today's capacity", async () => {
+			// 10 due today at target 10 (threshold 12) would normally stay put,
+			// but 8 reviews already done leave capacity 2 (threshold 2+2=4):
+			// 10 > 4 triggers and the day trims down to the remaining 2.
+			const cards = createCardsOnDate("2026-02-01", 10);
+			mockStore = createMockCardStore(cards);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+			service = new LoadBalanceService(mockStore);
+
+			const result = await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20,
+				completedToday: 8,
+				dryRun: true,
+			});
+
+			expect(result.affectedCount).toBe(8);
+		});
+
+		it("ignores New-state cards when counting and moving", async () => {
+			// 10 review cards + 5 new cards on today; effective count 10 <= 12
+			const reviewCards = createCardsOnDate("2026-02-01", 10);
+			const newCards = createCardsOnDate("2026-02-01", 5).map((card, i) => ({
+				...card,
+				id: `new-${i}`,
+				state: State.New,
+			}));
+			const cards = [...reviewCards, ...newCards];
+			mockStore = createMockCardStore(cards);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+			service = new LoadBalanceService(mockStore);
+
+			const result = await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20,
+				dryRun: true,
+			});
+
+			expect(result.affectedCount).toBe(0);
+		});
+
+		it("moves the longest-interval cards out of an overloaded day", async () => {
+			// scheduledDays run 7..21; trims to target 10 → the 5 longest move
+			const cards = createCardsOnDate("2026-02-01", 15);
+			mockStore = createMockCardStore(cards);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+			service = new LoadBalanceService(mockStore);
+
+			const result = await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20,
+				dryRun: true,
+			});
+
+			const movedIds = result.changes.map((c) => c.cardId).sort();
+			expect(movedIds).toEqual([
+				"card-2026-02-01-10",
+				"card-2026-02-01-11",
+				"card-2026-02-01-12",
+				"card-2026-02-01-13",
+				"card-2026-02-01-14",
+			]);
+		});
+	});
+
+	describe("auto target", () => {
+		it("computes the auto target as the average daily workload", () => {
+			// 62 cards over a 31-day window (today + 30) → 2/day
+			const cards = [
+				...createCardsOnDate("2026-01-20", 31),
+				...createCardsOnDate("2026-02-05", 31),
+			];
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+
+			expect(service.computeAutoTarget()).toBe(2);
+		});
+
+		it("weights easy days as a fraction of a normal day", () => {
+			const cards = createCardsOnDate("2026-02-05", 62);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+
+			// All days easy at 0.5 → 15.5 weighted days → 62 / 15.5 = 4
+			expect(
+				service.computeAutoTarget(
+					createEasyDaysConfig([0, 1, 2, 3, 4, 5, 6], []),
+					0.5,
+				),
+			).toBe(4);
+		});
+
+		it("balances against the derived target when none is given", async () => {
+			// 20 cards today, auto target = round(20/31) = 1 → threshold 1.2
+			const cards = createCardsOnDate("2026-02-01", 20);
+			mockStore = createMockCardStore(cards);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+			service = new LoadBalanceService(mockStore);
+
+			const result = await service.balance({
+				maxDeviation: 20,
+				dryRun: true,
+			});
+
+			expect(result.affectedCount).toBe(19);
+			result.changes.forEach((change) => {
+				expect(change.newDue).not.toContain("2026-02-01");
+			});
+		});
+	});
+
+	describe("cardIds scoping", () => {
+		it("moves only cards from the given subset", async () => {
+			// 15 cards today, threshold 12 → 3 excess, but only 2 movable
+			const cards = createCardsOnDate("2026-02-01", 15);
+			mockStore = createMockCardStore(cards);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+			service = new LoadBalanceService(mockStore);
+
+			const result = await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20,
+				cardIds: ["card-2026-02-01-0", "card-2026-02-01-5"],
+				dryRun: true,
+			});
+
+			expect(result.affectedCount).toBe(2);
+			expect(result.changes.map((c) => c.cardId).sort()).toEqual([
+				"card-2026-02-01-0",
+				"card-2026-02-01-5",
+			]);
+		});
+
+		it("still counts non-movable cards toward day capacity", async () => {
+			// Day is within threshold only because all 15 cards count; the
+			// movable pair must not be moved when the day is not overloaded.
+			const cards = createCardsOnDate("2026-02-01", 12);
+			mockStore = createMockCardStore(cards);
+			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
+			service = new LoadBalanceService(mockStore);
+
+			const result = await service.balance({
+				targetPerDay: 10,
+				maxDeviation: 20, // threshold 12, day exactly at limit
+				cardIds: ["card-2026-02-01-0", "card-2026-02-01-5"],
+				dryRun: true,
+			});
+
+			expect(result.affectedCount).toBe(0);
+		});
+	});
+
+	describe("balanceDue hot path", () => {
+		it("builds its distribution from aggregated counts, not full card rows", () => {
+			mockStore.getDueCountsByDateRange.mockReturnValue([
+				{ day: "2026-02-05", count: 12 },
+			]);
+
 			const result = service.balanceDue({
 				cardId: "current-card",
 				originalDue: "2026-02-05T10:00:00.000Z",
-				targetPerDay: 10,
-				maxDeviation: 20,
+				maxShiftDays: 3,
+			});
+
+			expect(result.balanced).toBe(true);
+			expect(mockStore.getDueCountsByDateRange).toHaveBeenCalled();
+			expect(mockStore.getDueCardsByDateRange).not.toHaveBeenCalled();
+		});
+
+		it("excludes the balanced card itself from the counts", () => {
+			mockStore.getDueCountsByDateRange.mockReturnValue([]);
+
+			service.balanceDue({
+				cardId: "current-card",
+				originalDue: "2026-02-05T10:00:00.000Z",
+				maxShiftDays: 3,
+			});
+
+			expect(mockStore.getDueCountsByDateRange).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(String),
+				"current-card",
+			);
+		});
+
+		it("derives the auto target from aggregated counts when no target is given", () => {
+			// 62 cards over the 31-day window → target 2/day
+			mockStore.getDueCountsByDateRange.mockReturnValue([
+				{ day: "2026-02-05", count: 62 },
+			]);
+
+			expect(service.computeAutoTarget()).toBe(2);
+			expect(mockStore.getDueCardsByDateRange).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("balanceDue (Anki-style fuzz balancing)", () => {
+		it("keeps the original day when it is the least loaded in the fuzz range", () => {
+			// interval 4 → candidates days 3-5; neighbors loaded, target day empty
+			mockStore.getDueCountsByDateRange.mockReturnValue([
+				{ day: "2026-02-04", count: 50 },
+				{ day: "2026-02-06", count: 50 },
+			]);
+
+			const result = service.balanceDue({
+				cardId: "current-card",
+				originalDue: "2026-02-05T10:00:00.000Z",
 				maxShiftDays: 3,
 			});
 
@@ -245,27 +511,81 @@ describe("LoadBalanceService", () => {
 			expect(result.newDue).toBe("2026-02-05T10:00:00.000Z");
 		});
 
-		it("moves a newly scheduled due date within max shift when target day is full", () => {
-			const cards = [
-				...createCardsOnDate("2026-02-05", 12),
-				...createCardsOnDate("2026-02-06", 1),
-			];
-			mockStore = createMockCardStore(cards);
-			mockStore.getDueCardsByDateRange.mockReturnValue(cards);
-			service = new LoadBalanceService(mockStore);
+		it("moves off a loaded day within the fuzz range, keeping time-of-day", () => {
+			mockStore.getDueCountsByDateRange.mockReturnValue([
+				{ day: "2026-02-05", count: 12 },
+			]);
 
 			const result = service.balanceDue({
 				cardId: "current-card",
 				originalDue: "2026-02-05T10:00:00.000Z",
-				targetPerDay: 10,
-				maxDeviation: 20,
 				maxShiftDays: 3,
 			});
 
 			expect(result.balanced).toBe(true);
 			expect(Math.abs(result.daysChanged)).toBeLessThanOrEqual(3);
-			expect(result.newDue).not.toBe("2026-02-05T10:00:00.000Z");
 			expect(result.newDue.endsWith("T10:00:00.000Z")).toBe(true);
+			expect(["2026-02-04", "2026-02-06"]).toContain(
+				result.newDue.split("T")[0],
+			);
+		});
+
+		it("skips intervals under 2.5 days like Anki", () => {
+			const result = service.balanceDue({
+				cardId: "current-card",
+				originalDue: "2026-02-03T10:00:00.000Z",
+				maxShiftDays: 3,
+			});
+
+			expect(result.balanced).toBe(false);
+			expect(mockStore.getDueCountsByDateRange).not.toHaveBeenCalled();
+		});
+
+		it("skips intervals beyond the 90-day balancing horizon", () => {
+			const result = service.balanceDue({
+				cardId: "current-card",
+				originalDue: "2026-06-01T10:00:00.000Z",
+				maxShiftDays: 14,
+			});
+
+			expect(result.balanced).toBe(false);
+			expect(mockStore.getDueCountsByDateRange).not.toHaveBeenCalled();
+		});
+
+		it("caps the shift at maxShiftDays even when the fuzz range is wider", () => {
+			// interval 30 → fuzz range ~27-33, but maxShiftDays 1 → days 29-31
+			mockStore.getDueCountsByDateRange.mockReturnValue([
+				{ day: "2026-03-03", count: 40 },
+			]);
+
+			const result = service.balanceDue({
+				cardId: "current-card",
+				originalDue: "2026-03-03T10:00:00.000Z",
+				maxShiftDays: 1,
+			});
+
+			expect(result.balanced).toBe(true);
+			expect(Math.abs(result.daysChanged)).toBeLessThanOrEqual(1);
+		});
+
+		it("is deterministic for the same card and target day", () => {
+			mockStore.getDueCountsByDateRange.mockReturnValue([
+				{ day: "2026-02-05", count: 12 },
+			]);
+
+			const first = service.balanceDue({
+				cardId: "current-card",
+				originalDue: "2026-02-05T10:00:00.000Z",
+				maxShiftDays: 3,
+			});
+			const second = service.balanceDue({
+				cardId: "current-card",
+				originalDue: "2026-02-05T10:00:00.000Z",
+				maxShiftDays: 3,
+			});
+
+			expect(second.newDue).toBe(first.newDue);
+			expect(second.balanced).toBe(first.balanced);
 		});
 	});
 

--- a/packages/obsidian/src/features/study/ui/dashboard/components/ProjectsTab.tsx
+++ b/packages/obsidian/src/features/study/ui/dashboard/components/ProjectsTab.tsx
@@ -70,6 +70,8 @@ export function ProjectsTab({
 		handleRescheduleRecent,
 		handleScheduleBreak,
 		handleFlatten,
+		handleBalance,
+		handleForecast,
 	} = useProjectScheduling();
 	const {
 		dragState,
@@ -203,6 +205,8 @@ export function ProjectsTab({
 								onRescheduleRecent={handleRescheduleRecent}
 								onScheduleBreak={handleScheduleBreak}
 								onFlatten={handleFlatten}
+								onBalance={handleBalance}
+								onForecast={handleForecast}
 								onDragStart={handleDragStart}
 								onDragEnd={handleDragEnd}
 								onDragOver={handleDragOver}
@@ -311,6 +315,8 @@ interface ProjectHeaderItemProps {
 	onRescheduleRecent: (path: string, name: string) => Promise<void>;
 	onScheduleBreak: (path: string, name: string) => Promise<void>;
 	onFlatten: (path: string, name: string) => Promise<void>;
+	onBalance: (path: string, name: string) => Promise<void>;
+	onForecast: (path: string, name: string) => Promise<void>;
 	onDragStart: (e: DragEvent, item: FlatProjectItem) => void;
 	onDragEnd: () => void;
 	onDragOver: (e: DragEvent, item: FlatProjectItem) => void;
@@ -338,6 +344,8 @@ function ProjectHeaderItem({
 	onRescheduleRecent,
 	onScheduleBreak,
 	onFlatten,
+	onBalance,
+	onForecast,
 	onDragStart,
 	onDragEnd,
 	onDragOver,
@@ -413,6 +421,12 @@ function ProjectHeaderItem({
 		onFlatten: isVirtual
 			? undefined
 			: () => void onFlatten(item.project.path, item.project.name),
+		onBalance: isVirtual
+			? undefined
+			: () => void onBalance(item.project.path, item.project.name),
+		onForecast: isVirtual
+			? undefined
+			: () => void onForecast(item.project.path, item.project.name),
 	});
 
 	return (

--- a/packages/obsidian/src/features/study/ui/dashboard/helpers/use-project-context-menu.ts
+++ b/packages/obsidian/src/features/study/ui/dashboard/helpers/use-project-context-menu.ts
@@ -25,6 +25,8 @@ interface UseProjectContextMenuOptions {
 	onRescheduleRecent?: () => void;
 	onScheduleBreak?: () => void;
 	onFlatten?: () => void;
+	onBalance?: () => void;
+	onForecast?: () => void;
 }
 
 export function useProjectContextMenu({
@@ -49,6 +51,8 @@ export function useProjectContextMenu({
 	onRescheduleRecent,
 	onScheduleBreak,
 	onFlatten,
+	onBalance,
+	onForecast,
 }: UseProjectContextMenuOptions) {
 	const menuItems: MenuItem[] = [
 		{ title: "Study", icon: "play", onClick: onStudyProject },
@@ -91,6 +95,12 @@ export function useProjectContextMenu({
 						icon: "calendar-clock",
 						children: [
 							{
+								title: "Workload forecast…",
+								icon: "line-chart",
+								onClick: () => onForecast?.(),
+							},
+							"separator" as const,
+							{
 								title: "Reschedule all cards",
 								icon: "refresh-cw",
 								onClick: () => onReschedule?.(),
@@ -120,6 +130,11 @@ export function useProjectContextMenu({
 								title: "Flatten future due cards…",
 								icon: "bar-chart-2",
 								onClick: () => onFlatten?.(),
+							},
+							{
+								title: "Balance workload…",
+								icon: "scale",
+								onClick: () => onBalance?.(),
 							},
 						],
 					},

--- a/packages/obsidian/src/features/study/ui/dashboard/helpers/use-project-scheduling.ts
+++ b/packages/obsidian/src/features/study/ui/dashboard/helpers/use-project-scheduling.ts
@@ -7,10 +7,13 @@ import type { FSRSCardData } from "@true-recall/core/types";
 import { FSRSHelperCommand } from "@true-recall/obsidian/commands/commands/fsrs-helper.cmd";
 import { confirm } from "@true-recall/obsidian/modals/shared/ConfirmModal";
 import { promptText } from "@true-recall/obsidian/modals/shared/TextInputModal";
+import { ProjectForecastModal } from "@true-recall/obsidian/modals/study/ProjectForecastModal";
 import { usePlugin } from "@true-recall/obsidian/preact";
 import { notify } from "@true-recall/obsidian/services/notification.service";
 
 type ShiftAction = "postpone" | "advance";
+
+const PROJECT_FORECAST_DAYS = 30;
 
 export function useProjectScheduling() {
 	const plugin = usePlugin();
@@ -270,6 +273,119 @@ export function useProjectScheduling() {
 		[plugin, getProjectCards, applyChanges],
 	);
 
+	const handleBalance = useCallback(
+		async (projectPath: string, projectName: string) => {
+			const cardIds = getProjectCards(projectPath)
+				.filter((c) => c.state !== State.New && !c.suspended)
+				.map((c) => c.id);
+			if (cardIds.length === 0) {
+				notify().info("No reviewed cards in this project.");
+				return;
+			}
+
+			try {
+				const preview = plugin.fsrsHelper?.balanceWorkload({
+					cardIds,
+					dryRun: true,
+				});
+				if (!preview || preview.affectedCount === 0) {
+					notify().info("This project is already balanced.");
+					return;
+				}
+
+				const confirmed = await confirm(plugin.app, {
+					title: "Balance project",
+					message: `Move ${preview.affectedCount} cards in "${projectName}" to less loaded days? Cards from other projects stay untouched.`,
+					confirmLabel: "Balance",
+				});
+				if (!confirmed) return;
+
+				const result = plugin.fsrsHelper?.balanceWorkload({
+					cardIds,
+					dryRun: false,
+				});
+				if (result && result.affectedCount > 0) {
+					applyChanges(
+						result,
+						`Balance "${projectName}" (${result.affectedCount} cards)`,
+					);
+					notify().success(
+						`Balanced ${result.affectedCount} cards (Ctrl+Z to undo)`,
+					);
+				} else {
+					notify().info("No cards needed balancing.");
+				}
+			} catch (err) {
+				notify().error(`Balance failed: ${String(err)}`);
+			}
+		},
+		[plugin, getProjectCards, applyChanges],
+	);
+
+	const handleForecast = useCallback(
+		async (projectPath: string, projectName: string) => {
+			const helper = plugin.fsrsHelper;
+			if (!helper) return;
+
+			const include: ReadonlySet<string> =
+				plugin.hierarchyService.getSourceUidsForProject(projectPath);
+			if (include.size === 0) {
+				notify().info("No notes in this project.");
+				return;
+			}
+
+			const forecast = helper.getWorkloadForecast(
+				PROJECT_FORECAST_DAYS,
+				undefined,
+				include,
+			);
+			const total = forecast.reduce((sum, entry) => sum + entry.dueCount, 0);
+			if (total === 0) {
+				notify().info("No reviews scheduled in this project's next 30 days.");
+				return;
+			}
+
+			// The reference target is the project's own average, so the summary
+			// describes how even this project is — not its share of the global goal
+			const projectTarget = Math.max(
+				1,
+				Math.round(total / Math.max(1, forecast.length)),
+			);
+			const summary = helper.getWorkloadForecastSummary(
+				PROJECT_FORECAST_DAYS,
+				undefined,
+				include,
+				projectTarget,
+			);
+			const dayOfWeek = helper.getWorkloadByDayOfWeek(
+				PROJECT_FORECAST_DAYS,
+				undefined,
+				include,
+			);
+
+			const movableIds = getProjectCards(projectPath)
+				.filter((c) => c.state !== State.New && !c.suspended)
+				.map((c) => c.id);
+			const dryRun =
+				movableIds.length > 0
+					? helper.balanceWorkload({ cardIds: movableIds, dryRun: true })
+					: null;
+			const canBalance = (dryRun?.affectedCount ?? 0) > 0;
+
+			const modal = new ProjectForecastModal(plugin.app, projectName, {
+				forecast,
+				summary: { ...summary, needsBalancing: canBalance },
+				dayOfWeek,
+				canBalance,
+			});
+			const action = await modal.openAndWait();
+			if (action === "balance") {
+				await handleBalance(projectPath, projectName);
+			}
+		},
+		[plugin, getProjectCards, handleBalance],
+	);
+
 	const handleFlatten = useCallback(
 		async (projectPath: string, projectName: string) => {
 			const cardIds = getProjectCards(projectPath)
@@ -341,5 +457,7 @@ export function useProjectScheduling() {
 		handleRescheduleRecent,
 		handleScheduleBreak,
 		handleFlatten,
+		handleBalance,
+		handleForecast,
 	};
 }

--- a/packages/obsidian/src/modals/shared/preset-options/ParametersSection.tsx
+++ b/packages/obsidian/src/modals/shared/preset-options/ParametersSection.tsx
@@ -41,7 +41,7 @@ export function ParametersSection({
 	const handleOptimize = useCallback(async () => {
 		setOptimizing(true);
 		try {
-			const result = plugin.fsrsHelper?.optimizeParameters(
+			const result = await plugin.fsrsHelper?.optimizeParameters(
 				undefined,
 				preset.name,
 				preset.weights,

--- a/packages/obsidian/src/modals/study/ProjectForecastModal.tsx
+++ b/packages/obsidian/src/modals/study/ProjectForecastModal.tsx
@@ -1,0 +1,88 @@
+import type { App } from "obsidian";
+import { render } from "preact";
+
+import type {
+	WorkloadForecastEntry,
+	WorkloadForecastSummary,
+} from "@true-recall/core/metrics/fsrs-tools/statistics/workload-forecast.calculator";
+
+import { Clickable } from "@true-recall/obsidian/components";
+import { WorkloadForecastSection } from "@true-recall/obsidian/features/metrics/ui/stats/components/WorkloadForecastSection";
+import { BasePromiseModal } from "@true-recall/obsidian/modals/shared/BasePromiseModal";
+
+export interface ProjectForecastData {
+	forecast: WorkloadForecastEntry[];
+	summary: WorkloadForecastSummary;
+	dayOfWeek: { day: number; dayName: string; avgCount: number }[];
+	/** Whether a scoped dry run found cards worth moving */
+	canBalance: boolean;
+}
+
+type ProjectForecastAction = "balance" | "close";
+
+function ProjectForecastBody({
+	data,
+	onResolve,
+}: {
+	data: ProjectForecastData;
+	onResolve: (action: ProjectForecastAction) => void;
+}) {
+	return (
+		<>
+			<div class="ep:text-ui-small ep:text-obs-muted ep:mb-2">
+				Only this project's cards; the daily reference line is the project's
+				own 30-day average.
+			</div>
+			<WorkloadForecastSection
+				forecast={data.forecast}
+				summary={data.summary}
+				dayOfWeek={data.dayOfWeek}
+			/>
+			<div class="ep-modal-footer ep:flex ep:justify-end ep:gap-2 ep:mt-3">
+				<Clickable
+					class="ep-btn ep-btn-outline"
+					onClick={() => onResolve("close")}
+					stopPropagation={false}
+				>
+					Close
+				</Clickable>
+				{data.canBalance && (
+					<Clickable
+						class="ep-btn mod-cta"
+						onClick={() => onResolve("balance")}
+						stopPropagation={false}
+					>
+						Balance this project…
+					</Clickable>
+				)}
+			</div>
+		</>
+	);
+}
+
+export class ProjectForecastModal extends BasePromiseModal<ProjectForecastAction> {
+	constructor(
+		app: App,
+		projectName: string,
+		private data: ProjectForecastData,
+	) {
+		super(app, {
+			title: `Workload forecast — ${projectName}`,
+			width: "680px",
+		});
+	}
+
+	protected getDefaultResult(): ProjectForecastAction {
+		return "close";
+	}
+
+	protected renderBody(container: HTMLElement): void {
+		render(
+			<ProjectForecastBody
+				data={this.data}
+				onResolve={(action) => this.resolve(action)}
+			/>,
+			container,
+		);
+	}
+}

--- a/packages/obsidian/src/plugin/api/handlers/fsrs-advanced.ts
+++ b/packages/obsidian/src/plugin/api/handlers/fsrs-advanced.ts
@@ -3,11 +3,11 @@ import { FSRSSimulatorService } from "@true-recall/core/services/fsrs/fsrs-simul
 import type { ApiContext, ApiRequest, ApiResponseWriter } from "../api.types";
 import { parseJsonBody, readBody, sendError, sendOk } from "../api.types";
 
-export function handleOptimizeParameters(
+export async function handleOptimizeParameters(
 	req: ApiRequest,
 	res: ApiResponseWriter,
 	ctx: ApiContext,
-): void {
+): Promise<void> {
 	if (!ctx.plugin.isStoreReady()) {
 		sendError(res, 503, "Database not ready");
 		return;
@@ -28,7 +28,7 @@ export function handleOptimizeParameters(
 	const currentWeights = preset?.weights ?? ctx.plugin.settings.fsrsWeights;
 
 	try {
-		const result = ctx.plugin.fsrsHelper.optimizeParameters(
+		const result = await ctx.plugin.fsrsHelper.optimizeParameters(
 			{},
 			presetName,
 			currentWeights,
@@ -93,15 +93,29 @@ export function handleGetWorkloadForecast(
 
 	const url = new URL(req.url ?? "/", "http://localhost");
 	const days = Number(url.searchParams.get("days")) || 30;
+	const project = url.searchParams.get("project");
+
+	let includeUids: ReadonlySet<string> | undefined;
+	if (project) {
+		const sourceUids =
+			ctx.plugin.hierarchyService.getSourceUidsForProject(project);
+		if (sourceUids.size === 0) {
+			sendError(res, 404, `Project "${project}" not found or has no notes`);
+			return;
+		}
+		includeUids = sourceUids;
+	}
 
 	const archivedUids = ctx.plugin.hierarchyService.getArchivedSourceUids();
 	const forecast = ctx.plugin.fsrsHelper.getWorkloadForecast(
 		days,
 		archivedUids,
+		includeUids,
 	);
 	const byDay = ctx.plugin.fsrsHelper.getWorkloadByDayOfWeek(
 		days,
 		archivedUids,
+		includeUids,
 	);
 
 	sendOk(res, { forecast, byDayOfWeek: byDay });

--- a/packages/obsidian/src/plugin/api/handlers/fsrs.ts
+++ b/packages/obsidian/src/plugin/api/handlers/fsrs.ts
@@ -1,3 +1,5 @@
+import type { FSRSPreset, TrueRecallSettings } from "@true-recall/core/types";
+
 import type { ApiContext, ApiRequest, ApiResponseWriter } from "../api.types";
 import { parseJsonBody, readBody, sendError, sendOk } from "../api.types";
 
@@ -73,6 +75,193 @@ export async function handleCreatePreset(
 	});
 
 	sendOk(res, { id: preset.id, name: preset.name });
+}
+
+interface UpdatePresetInput {
+	request_retention?: number;
+	new_cards_per_day?: number;
+	reviews_per_day?: number;
+	learning_steps?: number[];
+	relearning_steps?: number[];
+	leech_threshold?: number;
+	leech_action?: string;
+	weights?: number[] | null;
+}
+
+export async function handleUpdatePreset(
+	req: ApiRequest,
+	res: ApiResponseWriter,
+	ctx: ApiContext,
+	params: Record<string, string>,
+): Promise<void> {
+	const key = decodeURIComponent(params.id ?? "");
+	const preset =
+		ctx.plugin.presetService.getPresetById(key) ??
+		ctx.plugin.presetService.getPresetByName(key);
+	if (!preset) {
+		sendError(res, 404, `Preset "${key}" not found (by id or name)`);
+		return;
+	}
+
+	const raw = await readBody(req);
+	const body = parseJsonBody<UpdatePresetInput>(raw);
+	if (!body) {
+		sendError(res, 400, "Invalid JSON body");
+		return;
+	}
+
+	const changes: Partial<Omit<FSRSPreset, "id">> = {};
+	if (body.request_retention !== undefined) {
+		if (body.request_retention < 0.7 || body.request_retention > 0.99) {
+			sendError(res, 400, "request_retention must be between 0.70 and 0.99");
+			return;
+		}
+		changes.requestRetention = body.request_retention;
+	}
+	if (body.new_cards_per_day !== undefined) {
+		if (body.new_cards_per_day < 0) {
+			sendError(res, 400, "new_cards_per_day must be >= 0");
+			return;
+		}
+		changes.newCardsPerDay = Math.round(body.new_cards_per_day);
+	}
+	if (body.reviews_per_day !== undefined) {
+		if (body.reviews_per_day < 0) {
+			sendError(res, 400, "reviews_per_day must be >= 0");
+			return;
+		}
+		changes.reviewsPerDay = Math.round(body.reviews_per_day);
+	}
+	if (body.learning_steps !== undefined) {
+		changes.learningSteps = body.learning_steps;
+	}
+	if (body.relearning_steps !== undefined) {
+		changes.relearningSteps = body.relearning_steps;
+	}
+	if (body.leech_threshold !== undefined) {
+		changes.leechThreshold = Math.round(body.leech_threshold);
+	}
+	if (body.leech_action !== undefined) {
+		if (body.leech_action !== "tag-only" && body.leech_action !== "suspend") {
+			sendError(res, 400, 'leech_action must be "tag-only" or "suspend"');
+			return;
+		}
+		changes.leechAction = body.leech_action;
+	}
+	if (body.weights !== undefined) {
+		if (
+			body.weights !== null &&
+			!ctx.plugin.fsrsHelper?.validateWeights(body.weights)
+		) {
+			sendError(
+				res,
+				400,
+				"weights must be null or an array of 21 non-negative numbers",
+			);
+			return;
+		}
+		changes.weights = body.weights;
+	}
+
+	if (Object.keys(changes).length === 0) {
+		sendError(res, 400, "No recognized fields to update");
+		return;
+	}
+
+	await ctx.plugin.presetService.updatePreset(preset.id, changes);
+	sendOk(res, {
+		id: preset.id,
+		name: preset.name,
+		updated: Object.keys(changes),
+	});
+}
+
+interface LoadBalanceSettingsInput {
+	enabled?: boolean;
+	target_mode?: string;
+	target?: number;
+	max_deviation?: number;
+	max_shift_days?: number;
+	bulk_days?: number;
+}
+
+export async function handleUpdateLoadBalanceSettings(
+	req: ApiRequest,
+	res: ApiResponseWriter,
+	ctx: ApiContext,
+): Promise<void> {
+	const raw = await readBody(req);
+	const body = parseJsonBody<LoadBalanceSettingsInput>(raw);
+	if (!body) {
+		sendError(res, 400, "Invalid JSON body");
+		return;
+	}
+
+	const settings: TrueRecallSettings = ctx.plugin.settings;
+	const updated: string[] = [];
+
+	if (body.enabled !== undefined) {
+		settings.loadBalanceEnabled = Boolean(body.enabled);
+		updated.push("enabled");
+	}
+	if (body.target_mode !== undefined) {
+		if (body.target_mode !== "auto" && body.target_mode !== "manual") {
+			sendError(res, 400, 'target_mode must be "auto" or "manual"');
+			return;
+		}
+		settings.loadBalanceTargetMode = body.target_mode;
+		updated.push("target_mode");
+	}
+	if (body.target !== undefined) {
+		if (body.target < 1) {
+			sendError(res, 400, "target must be >= 1");
+			return;
+		}
+		settings.loadBalanceTarget = Math.round(body.target);
+		updated.push("target");
+	}
+	if (body.max_deviation !== undefined) {
+		if (body.max_deviation < 0 || body.max_deviation > 100) {
+			sendError(res, 400, "max_deviation must be between 0 and 100");
+			return;
+		}
+		settings.loadBalanceMaxDeviation = Math.round(body.max_deviation);
+		updated.push("max_deviation");
+	}
+	if (body.max_shift_days !== undefined) {
+		if (body.max_shift_days < 0) {
+			sendError(res, 400, "max_shift_days must be >= 0");
+			return;
+		}
+		settings.loadBalanceMaxShiftDays = Math.round(body.max_shift_days);
+		updated.push("max_shift_days");
+	}
+	if (body.bulk_days !== undefined) {
+		if (body.bulk_days < 0) {
+			sendError(res, 400, "bulk_days must be >= 0");
+			return;
+		}
+		settings.loadBalanceBulkDays = Math.round(body.bulk_days);
+		updated.push("bulk_days");
+	}
+
+	if (updated.length === 0) {
+		sendError(res, 400, "No recognized fields to update");
+		return;
+	}
+
+	await ctx.plugin.saveSettings();
+	sendOk(res, {
+		updated,
+		loadBalance: {
+			enabled: settings.loadBalanceEnabled,
+			targetMode: settings.loadBalanceTargetMode,
+			target: settings.loadBalanceTarget,
+			maxDeviation: settings.loadBalanceMaxDeviation,
+			maxShiftDays: settings.loadBalanceMaxShiftDays,
+			bulkDays: settings.loadBalanceBulkDays,
+		},
+	});
 }
 
 export function handleGetFsrsStats(

--- a/packages/obsidian/src/plugin/api/routes.ts
+++ b/packages/obsidian/src/plugin/api/routes.ts
@@ -38,6 +38,8 @@ import {
 	handleCreatePreset,
 	handleGetFsrsStats,
 	handleGetPresets,
+	handleUpdateLoadBalanceSettings,
+	handleUpdatePreset,
 } from "./handlers/fsrs";
 import {
 	handleGetRetrievability,
@@ -172,6 +174,8 @@ const routes: Route[] = [
 	// FSRS
 	route("GET", "/presets", handleGetPresets),
 	route("POST", "/presets", handleCreatePreset),
+	route("POST", "/presets/:id", handleUpdatePreset),
+	route("POST", "/settings/load-balance", handleUpdateLoadBalanceSettings),
 	route("GET", "/fsrs/stats", handleGetFsrsStats),
 
 	// Navigation

--- a/packages/obsidian/src/settings/tabs/fsrs/LoadBalanceSection.tsx
+++ b/packages/obsidian/src/settings/tabs/fsrs/LoadBalanceSection.tsx
@@ -23,6 +23,10 @@ interface LoadBalanceSectionProps {
 }
 
 const FORECAST_DAYS = 30;
+const TARGET_MODE_OPTIONS = [
+	{ value: "auto", label: "Automatic (forecast average)" },
+	{ value: "manual", label: "Manual" },
+];
 const BALANCE_RANGE_OPTIONS = [
 	{ value: "30", label: "Next 30 days" },
 	{ value: "60", label: "Next 60 days" },
@@ -72,16 +76,19 @@ export function LoadBalanceSection({
 		// deviation sliders below (they only call `save`, not setForecastVersion).
 		void forecastVersion;
 		void settings.loadBalanceTarget;
+		void settings.loadBalanceTargetMode;
 		void settings.loadBalanceMaxDeviation;
 		return {
 			forecast: helper.getWorkloadForecast(FORECAST_DAYS),
 			summary: helper.getWorkloadForecastSummary(FORECAST_DAYS),
 			dayOfWeek: helper.getWorkloadByDayOfWeek(FORECAST_DAYS),
+			effectiveTarget: helper.getEffectiveLoadBalanceTarget(),
 		};
 	}, [
 		plugin.fsrsHelper,
 		forecastVersion,
 		settings.loadBalanceTarget,
+		settings.loadBalanceTargetMode,
 		settings.loadBalanceMaxDeviation,
 	]);
 
@@ -113,18 +120,39 @@ export function LoadBalanceSection({
 			</FormField>
 
 			<FormField
-				name="Target daily reviews"
-				description="Target number of reviews per day for balancing"
+				name="Daily target"
+				description={
+					settings.loadBalanceTargetMode === "auto" && forecastData
+						? `Automatic: ~${forecastData.effectiveTarget} reviews/day, the average of your upcoming workload (backlog included)`
+						: "How the daily review target is determined"
+				}
 			>
-				<TextInput
-					value={String(settings.loadBalanceTarget)}
-					onChange={(v) => {
-						const num = parseInt(v, 10) || 100;
-						void save({ loadBalanceTarget: Math.max(1, num) });
-					}}
-					placeholder="100"
+				<SelectInput
+					value={settings.loadBalanceTargetMode}
+					options={TARGET_MODE_OPTIONS}
+					onChange={(v) =>
+						void save({
+							loadBalanceTargetMode: v === "manual" ? "manual" : "auto",
+						})
+					}
 				/>
 			</FormField>
+
+			{settings.loadBalanceTargetMode === "manual" && (
+				<FormField
+					name="Target daily reviews"
+					description="Target number of reviews per day for balancing"
+				>
+					<TextInput
+						value={String(settings.loadBalanceTarget)}
+						onChange={(v) => {
+							const num = parseInt(v, 10) || 100;
+							void save({ loadBalanceTarget: Math.max(1, num) });
+						}}
+						placeholder="100"
+					/>
+				</FormField>
+			)}
 
 			<FormField
 				name="Maximum deviation (%)"
@@ -166,7 +194,7 @@ export function LoadBalanceSection({
 
 			<FormField
 				name="Balance workload now"
-				description="Apply load balancing immediately to existing scheduled reviews"
+				description="Apply load balancing immediately to scheduled reviews, spreading any overdue backlog from today forward"
 			>
 				<div class="ep:flex ep:items-center ep:gap-2">
 					<ActionButton

--- a/packages/obsidian/src/settings/tabs/fsrs/ParametersSection.tsx
+++ b/packages/obsidian/src/settings/tabs/fsrs/ParametersSection.tsx
@@ -39,7 +39,7 @@ export function ParametersSection({
 	const handleOptimize = useCallback(async () => {
 		setOptimizing(true);
 		try {
-			const result = plugin.fsrsHelper?.optimizeParameters(
+			const result = await plugin.fsrsHelper?.optimizeParameters(
 				undefined,
 				preset.name,
 				preset.weights,

--- a/packages/obsidian/src/views/stats/StatsApp.tsx
+++ b/packages/obsidian/src/views/stats/StatsApp.tsx
@@ -258,7 +258,17 @@ export function StatsApp({ isViewVisible }: StatsAppProps) {
 		if (renderStage < 2) return null;
 		const days = forecastRangeToDays(forecastRange.value, filteredCardFsrs);
 		const forecast = buildFilteredForecast(filteredCardFsrs, days);
-		const target = settings.loadBalanceTarget ?? 50;
+		// Auto mode mirrors the balancer: target = average of the shown forecast
+		const target =
+			settings.loadBalanceTargetMode === "manual"
+				? (settings.loadBalanceTarget ?? 50)
+				: Math.max(
+						1,
+						Math.round(
+							forecast.reduce((sum, entry) => sum + entry.dueCount, 0) /
+								Math.max(1, forecast.length),
+						),
+					);
 		const maxDeviation = settings.loadBalanceMaxDeviation ?? 20;
 		return {
 			forecast,
@@ -270,6 +280,7 @@ export function StatsApp({ isViewVisible }: StatsAppProps) {
 		filteredCardFsrs,
 		forecastRange.value,
 		settings.loadBalanceTarget,
+		settings.loadBalanceTargetMode,
 		settings.loadBalanceMaxDeviation,
 	]);
 


### PR DESCRIPTION
## Summary
- Load-balance daily target gets auto/manual modes; bulk balance spreads the overdue backlog forward from today and counts today's completed reviews against capacity
- Per-review balancing rewritten 1:1 to Anki's load_balancer.rs (constrained fuzz bounds, weighted-random day pick, deterministic per card/day)
- Replay-based FSRS optimizer: every candidate weight vector re-simulates full review histories, making all 21 parameters observable in the loss
- Per-project balance and workload forecast (dashboard context menu + modal)
- New API/CLI/MCP surfaces: update_fsrs_preset, set_load_balance, project-scoped forecast

## Test Plan
- [x] bun run test — full suite green (2249 tests on this branch)
- [x] bun run build — typecheck + bundle green