### PR TITLE
feat(obsidian): render Ink drawing/writing embeds in review and note editors

### DIFF
--- a/packages/obsidian/src/editor/shared/ink-embeddable-editor.ts
+++ b/packages/obsidian/src/editor/shared/ink-embeddable-editor.ts
@@ -1,0 +1,50 @@
+import type { Extension } from "@codemirror/state";
+
+interface InkEmbeddableEditorApi {
+	getEmbeddableEditorExtensions?: (sourcePath: string) => Extension[];
+}
+
+interface AppWithPluginManager {
+	plugins?: {
+		getPlugin?: (id: string) => unknown;
+		manifests?: Record<string, unknown>;
+	};
+}
+
+export type InkIntegrationStatus =
+	| "ready"
+	| "incompatible"
+	| "disabled"
+	| "not-installed";
+
+function getLoadedInkPlugin(app: unknown): InkEmbeddableEditorApi | null {
+	const pluginManager = (app as AppWithPluginManager).plugins;
+	return (pluginManager?.getPlugin?.("ink") as InkEmbeddableEditorApi) ?? null;
+}
+
+export function getInkIntegrationStatus(app: unknown): InkIntegrationStatus {
+	const pluginManager = (app as AppWithPluginManager).plugins;
+	const inkPlugin = getLoadedInkPlugin(app);
+
+	if (inkPlugin) {
+		return typeof inkPlugin.getEmbeddableEditorExtensions === "function"
+			? "ready"
+			: "incompatible";
+	}
+
+	return pluginManager?.manifests?.ink ? "disabled" : "not-installed";
+}
+
+/**
+ * Resolve the optional Ink integration without making True Recall depend on
+ * Ink at build time. An empty list keeps EmbeddableEditor usable when Ink is
+ * disabled, missing, or older than the shared-editor API.
+ */
+export function getInkEmbeddableEditorExtensions(
+	app: unknown,
+	sourcePath: string,
+): Extension[] {
+	const inkPlugin = getLoadedInkPlugin(app);
+
+	return inkPlugin?.getEmbeddableEditorExtensions?.(sourcePath) ?? [];
+}

--- a/packages/obsidian/src/features/study/ui/review/components/CardContainer.tsx
+++ b/packages/obsidian/src/features/study/ui/review/components/CardContainer.tsx
@@ -22,6 +22,13 @@ import { AudioPlayButton } from "./AudioPlayButton";
 import { NoteReviewRenderer } from "./NoteReviewRenderer";
 import { IOCardRenderer } from "@true-recall/plugins/image-occlusion";
 
+const INK_EMBED_PATTERN =
+	/(?:!\[Ink(?:Drawing|Writing)\]|[?&]type=ink(?:Drawing|Writing)\b)/i;
+
+function hasInkEmbed(content: string | undefined): boolean {
+	return !!content && INK_EMBED_PATTERN.test(content);
+}
+
 function useAnswerWarmup(
 	isRevealed: boolean,
 	cardId: string,
@@ -186,7 +193,12 @@ export function CardContainer({
 	// Detailed grading feedback is stripped for non-Pro tiers in
 	// SemanticAnswerGradingService — surface that instead of silently hiding it.
 	const isProTier = providerType === "pro";
-	const maxWidth = isMobile() ? "100%" : getReviewMaxWidth(reviewContentWidth);
+	const containsInkEmbed =
+		hasInkEmbed(card.question) || hasInkEmbed(card.answer);
+	const maxWidth =
+		isMobile() || containsInkEmbed
+			? "100%"
+			: getReviewMaxWidth(reviewContentWidth);
 	const maxWidthStyle = `--tr-review-max-width: ${maxWidth}; max-width: ${maxWidth};`;
 
 	const questionContent = card.question;

--- a/packages/obsidian/src/features/study/ui/review/components/LivePreviewField.tsx
+++ b/packages/obsidian/src/features/study/ui/review/components/LivePreviewField.tsx
@@ -11,6 +11,7 @@ import {
 import { stripBrTags } from "@true-recall/core/utils";
 
 import type { EmbeddableEditorInstance } from "@true-recall/obsidian/editor/shared/embedded-editor";
+import { getInkEmbeddableEditorExtensions } from "@true-recall/obsidian/editor/shared/ink-embeddable-editor";
 import { hasBlockMarkdown } from "@true-recall/obsidian/features/study/ui/review/helpers";
 import {
 	useApp,
@@ -131,6 +132,7 @@ export function LivePreviewField({
 				onBlur: handleBlur,
 				onEscape: handleEscape,
 				onChange: handleChange,
+				extraExtensions: getInkEmbeddableEditorExtensions(app, sourcePath),
 			});
 			editorRef.current = editor;
 		} catch (error) {
@@ -165,6 +167,7 @@ export function LivePreviewField({
 		handleEscape,
 		handleChange,
 		flushPendingSave,
+		sourcePath,
 	]);
 
 	// Update editor content when card changes (new card appears)

--- a/packages/obsidian/src/settings/tabs/IntegrationsTab.tsx
+++ b/packages/obsidian/src/settings/tabs/IntegrationsTab.tsx
@@ -10,12 +10,15 @@ import {
 } from "@true-recall/obsidian/components";
 
 import { useSettings } from "../hooks/useSettings";
+import { InkIntegrationSection } from "./integrations/InkIntegrationSection";
 
 export function IntegrationsTab() {
 	const { settings, save, plugin } = useSettings();
 
 	return (
 		<div class="ep:flex ep:flex-col ep:gap-3">
+			<InkIntegrationSection />
+
 			<FormCard title="Local API">
 				<InfoBlock>
 					Expose a local HTTP API for the True Recall CLI. Binds to 127.0.0.1

--- a/packages/obsidian/src/settings/tabs/integrations/InkIntegrationSection.tsx
+++ b/packages/obsidian/src/settings/tabs/integrations/InkIntegrationSection.tsx
@@ -1,0 +1,80 @@
+import {
+	Clickable,
+	FormCard,
+	FormField,
+	InfoBlock,
+} from "@true-recall/obsidian/components";
+import {
+	getInkIntegrationStatus,
+	type InkIntegrationStatus,
+} from "@true-recall/obsidian/editor/shared/ink-embeddable-editor";
+import { usePlugin } from "@true-recall/obsidian/preact";
+import { useIcon } from "@true-recall/obsidian/preact/hooks";
+
+const INK_GITHUB_URL = "https://github.com/daledesilva/obsidian_ink";
+
+const STATUS_COPY: Record<
+	InkIntegrationStatus,
+	{ label: string; description: string; class: string }
+> = {
+	ready: {
+		label: "Ready",
+		description:
+			"Ink is enabled and supports drawings inside True Recall editors.",
+		class: "ep:text-obs-accent",
+	},
+	incompatible: {
+		label: "Update required",
+		description:
+			"Ink is enabled, but this version does not expose the embedded-editor API required by True Recall. Install a True Recall-compatible Ink build, then reload Obsidian.",
+		class: "ep:text-obs-warning",
+	},
+	disabled: {
+		label: "Disabled",
+		description:
+			"Ink is installed but not loaded. Enable it under Community plugins, then reload Obsidian.",
+		class: "ep:text-obs-warning",
+	},
+	"not-installed": {
+		label: "Not installed",
+		description:
+			"Open Settings > Community plugins > Browse, search for Ink, install and enable it, then reload Obsidian.",
+		class: "ep:text-obs-muted",
+	},
+};
+
+export function InkIntegrationSection() {
+	const plugin = usePlugin();
+	const githubIconRef = useIcon("github");
+	const status = getInkIntegrationStatus(plugin.app);
+	const copy = STATUS_COPY[status];
+
+	return (
+		<FormCard title="Ink drawings">
+			<InfoBlock>
+				Ink is a separate Obsidian community plugin and is not bundled with True
+				Recall. Install and enable a compatible Ink version to create and edit
+				drawings directly in review cards and the Add/Edit Flashcard dialog.
+			</InfoBlock>
+
+			<FormField name="Integration status" description={copy.description}>
+				<span class={`ep:text-ui-small ep:font-medium ${copy.class}`}>
+					{copy.label}
+				</span>
+			</FormField>
+
+			<FormField
+				name="Ink plugin"
+				description="View installation instructions, releases, and source code"
+			>
+				<Clickable
+					class="ep-btn ep-btn-outline ep:inline-flex ep:items-center ep:gap-1.5"
+					onClick={() => window.open(INK_GITHUB_URL, "_blank")}
+				>
+					<div ref={githubIconRef} class="ep:w-4 ep:h-4" />
+					Open Ink on GitHub
+				</Clickable>
+			</FormField>
+		</FormCard>
+	);
+}

--- a/packages/obsidian/tests/editor/shared/ink-embeddable-editor.test.ts
+++ b/packages/obsidian/tests/editor/shared/ink-embeddable-editor.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	getInkEmbeddableEditorExtensions,
+	getInkIntegrationStatus,
+} from "../../../src/editor/shared/ink-embeddable-editor";
+
+describe("getInkEmbeddableEditorExtensions", () => {
+	it("returns no extensions when Ink is unavailable", () => {
+		const app = { plugins: { getPlugin: vi.fn(() => null) } };
+
+		expect(getInkEmbeddableEditorExtensions(app, "Notes/Card.md")).toEqual([]);
+		expect(app.plugins.getPlugin).toHaveBeenCalledWith("ink");
+	});
+
+	it("passes the source path to Ink and preserves the plugin receiver", () => {
+		const extension = {};
+		const inkPlugin = {
+			marker: "ink",
+			getEmbeddableEditorExtensions(this: { marker: string }, path: string) {
+				return [{ extension, marker: this.marker, path }];
+			},
+		};
+		const app = { plugins: { getPlugin: () => inkPlugin } };
+
+		expect(getInkEmbeddableEditorExtensions(app, "Notes/Card.md")).toEqual([
+			{ extension, marker: "ink", path: "Notes/Card.md" },
+		]);
+	});
+
+	it("supports older Ink versions without the shared-editor API", () => {
+		const app = { plugins: { getPlugin: () => ({}) } };
+
+		expect(getInkEmbeddableEditorExtensions(app, "")).toEqual([]);
+	});
+});
+
+describe("getInkIntegrationStatus", () => {
+	it.each([
+		[
+			"not installed",
+			{ plugins: { getPlugin: () => null, manifests: {} } },
+			"not-installed",
+		],
+		[
+			"installed but disabled",
+			{ plugins: { getPlugin: () => null, manifests: { ink: {} } } },
+			"disabled",
+		],
+		[
+			"enabled but incompatible",
+			{ plugins: { getPlugin: () => ({}), manifests: { ink: {} } } },
+			"incompatible",
+		],
+		[
+			"ready",
+			{
+				plugins: {
+					getPlugin: () => ({ getEmbeddableEditorExtensions: () => [] }),
+					manifests: { ink: {} },
+				},
+			},
+			"ready",
+		],
+	] as const)("reports %s", (_label, app, expected) => {
+		expect(getInkIntegrationStatus(app)).toBe(expected);
+	});
+});


### PR DESCRIPTION
## Summary
- Ink drawing/writing embeds render inside review cards and note editors via a shared CM6 editor extension
- Review card container goes full-width when a card contains an Ink embed
- New Integrations settings section for the Ink plugin

## Test Plan
- [x] bun run test — full suite green (2211 tests on this branch)
- [x] bun run build — typecheck + bundle green