### PR TITLE
feat: conscious daily target — pace-anchored suggestion with catch-up preview

### DIFF
--- a/packages/core/src/metrics/fsrs-tools/fsrs-helper.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/fsrs-helper.service.ts
@@ -38,6 +38,14 @@ import type {
 } from "./scheduler/scheduler.types";
 import { SiblingDisperseService } from "./scheduler/sibling-disperse.service";
 import {
+	type CatchUpProjection,
+	computePaceStats,
+	computeSuggestedTarget,
+	computeTargetFloor,
+	PACE_LOOKBACK_DAYS,
+	projectCatchUp,
+} from "./scheduler/target-suggestion";
+import {
 	DistributionCalculator,
 	type DistributionStats,
 	type HistogramBucket,
@@ -52,6 +60,27 @@ import {
 	type WorkloadForecastEntry,
 	type WorkloadForecastSummary,
 } from "./statistics/workload-forecast.calculator";
+
+/** Everything the daily-target picker needs to render a conscious choice */
+export interface WorkloadDecision {
+	/** Average upcoming dues per weighted day, backlog excluded */
+	steadyStatePerDay: number;
+	/** Overdue Review cards (due before today) */
+	backlogSize: number;
+	/** Pace below which the backlog grows */
+	targetFloor: number;
+	medianPace: number;
+	p75Pace: number;
+	activeDays: number;
+	/** Median pace floored at the water line; forecast average when history is thin */
+	suggestedTarget: number;
+	/** True when the legacy forecast average filled in for thin pace history */
+	usedPaceFallback: boolean;
+	/** Catch-up projection at the effective target */
+	catchUp: CatchUpProjection;
+	/** Manual target when configured, otherwise suggestedTarget */
+	effectiveTarget: number;
+}
 
 export class FSRSHelperService {
 	private optimizer: ParameterOptimizerService;
@@ -117,28 +146,73 @@ export class FSRSHelperService {
 		return this.optimizer.validateWeights(weights);
 	}
 
-	/** Manual target when configured, undefined in auto mode (core derives it) */
+	/** Manual target when configured, undefined in auto mode (suggestion derives it) */
 	private resolveLoadBalanceTarget(): number | undefined {
 		return this.settings.loadBalanceTargetMode === "manual"
 			? this.settings.loadBalanceTarget
 			: undefined;
 	}
 
-	/** The daily target actually in effect: manual value or forecast average */
+	/** The daily target actually in effect: manual value or the suggested target */
 	getEffectiveLoadBalanceTarget(): number {
-		return (
-			this.resolveLoadBalanceTarget() ??
+		return this.getWorkloadDecision().effectiveTarget;
+	}
+
+	/** Everything the daily-target picker needs to render a conscious choice */
+	getWorkloadDecision(): WorkloadDecision {
+		const steadyStatePerDay = this.loadBalancer.computeAutoTarget(
+			this.settings.easyDays,
+			this.settings.easyDaysMultiplier,
+			false,
+		);
+		const backlogSize = this.loadBalancer.getBacklogSize();
+		const pace = computePaceStats(this.getRecentDailyReviewCounts());
+		const paceTarget = computeSuggestedTarget(
+			pace,
+			steadyStatePerDay,
+			backlogSize,
+		);
+		const suggestedTarget =
+			paceTarget ??
 			this.loadBalancer.computeAutoTarget(
 				this.settings.easyDays,
 				this.settings.easyDaysMultiplier,
-			)
-		);
+			);
+		const effectiveTarget = this.resolveLoadBalanceTarget() ?? suggestedTarget;
+		return {
+			steadyStatePerDay,
+			backlogSize,
+			targetFloor: computeTargetFloor(steadyStatePerDay, backlogSize),
+			medianPace: pace.medianPace,
+			p75Pace: pace.p75Pace,
+			activeDays: pace.activeDays,
+			suggestedTarget,
+			usedPaceFallback: paceTarget === null,
+			catchUp: projectCatchUp(
+				effectiveTarget,
+				steadyStatePerDay,
+				backlogSize,
+				new Date(),
+			),
+			effectiveTarget,
+		};
+	}
+
+	/** Reviews completed per active day over the pace lookback window */
+	private getRecentDailyReviewCounts(): number[] {
+		const end = new Date();
+		const start = new Date(end);
+		start.setDate(start.getDate() - PACE_LOOKBACK_DAYS);
+		return this.cardStore.stats
+			.getDailyStatsFromReviewLog(formatLocalDate(start), formatLocalDate(end))
+			.map((day) => day.reviewsCompleted);
 	}
 
 	balanceWorkload(options?: Partial<LoadBalanceOptions>): SchedulingResult {
 		const days = options?.days ?? this.settings.loadBalanceBulkDays;
 		return this.loadBalancer.balance({
-			targetPerDay: options?.targetPerDay ?? this.resolveLoadBalanceTarget(),
+			targetPerDay:
+				options?.targetPerDay ?? this.getEffectiveLoadBalanceTarget(),
 			maxDeviation:
 				options?.maxDeviation ?? this.settings.loadBalanceMaxDeviation,
 			days: days === 0 ? 36500 : days,

--- a/packages/core/src/metrics/fsrs-tools/fsrs-helper.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/fsrs-helper.service.ts
@@ -1,7 +1,6 @@
 import { State } from "ts-fsrs";
 
 import type { SqliteStoreService } from "../../persistence/sqlite/SqliteStoreService";
-import { formatLocalDate, getTodayBoundary } from "../../utils";
 import type {
 	FSRSCardData,
 	FSRSSettings,
@@ -10,6 +9,7 @@ import type {
 	TrueRecallSettings,
 } from "../../types";
 import { formatInterval } from "../../types/fsrs/fsrs.utils";
+import { formatLocalDate, getTodayBoundary } from "../../utils";
 import type {
 	OptimizationInput,
 	OptimizationOutput,

--- a/packages/core/src/metrics/fsrs-tools/index.ts
+++ b/packages/core/src/metrics/fsrs-tools/index.ts
@@ -8,7 +8,17 @@
  */
 
 // Main service
-export { FSRSHelperService } from "./fsrs-helper.service";
+export {
+	FSRSHelperService,
+	type WorkloadDecision,
+} from "./fsrs-helper.service";
+export {
+	type CatchUpProjection,
+	MIN_ACTIVE_DAYS,
+	PACE_LOOKBACK_DAYS,
+	type PaceStats,
+	projectCatchUp,
+} from "./scheduler/target-suggestion";
 export type {
 	OptimizationInput,
 	OptimizationOutput,

--- a/packages/core/src/metrics/fsrs-tools/index.ts
+++ b/packages/core/src/metrics/fsrs-tools/index.ts
@@ -12,13 +12,6 @@ export {
 	FSRSHelperService,
 	type WorkloadDecision,
 } from "./fsrs-helper.service";
-export {
-	type CatchUpProjection,
-	MIN_ACTIVE_DAYS,
-	PACE_LOOKBACK_DAYS,
-	type PaceStats,
-	projectCatchUp,
-} from "./scheduler/target-suggestion";
 export type {
 	OptimizationInput,
 	OptimizationOutput,
@@ -51,6 +44,13 @@ export type {
 	WorkloadDistribution,
 } from "./scheduler/scheduler.types";
 export { SiblingDisperseService } from "./scheduler/sibling-disperse.service";
+export {
+	type CatchUpProjection,
+	MIN_ACTIVE_DAYS,
+	PACE_LOOKBACK_DAYS,
+	type PaceStats,
+	projectCatchUp,
+} from "./scheduler/target-suggestion";
 export {
 	DistributionCalculator,
 	type DistributionStats,

--- a/packages/core/src/metrics/fsrs-tools/optimizer/parameter-optimizer.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/optimizer/parameter-optimizer.service.ts
@@ -190,7 +190,10 @@ export class ParameterOptimizerService {
 	}
 
 	/** Replay all sequences with the given weights and score the predictions */
-	private evaluate(weights: number[], sequences: ReviewStep[][]): ReplayMetrics {
+	private evaluate(
+		weights: number[],
+		sequences: ReviewStep[][],
+	): ReplayMetrics {
 		const algorithm = new FSRSAlgorithm(
 			generatorParameters({ w: weights, enable_short_term: true }),
 		);

--- a/packages/core/src/metrics/fsrs-tools/scheduler/load-balance.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/scheduler/load-balance.service.ts
@@ -73,6 +73,13 @@ export class LoadBalanceService {
 		return Math.max(1, Math.round(totalCards / Math.max(1, weightedDays)));
 	}
 
+	/** Overdue Review cards: due strictly before today's UTC day key */
+	getBacklogSize(): number {
+		return this.cardStore
+			.getDueCountsByDateRange(OVERDUE_RANGE_START, this.dateFromToday(-1))
+			.reduce((sum, entry) => sum + entry.count, 0);
+	}
+
 	balance(options: LoadBalanceOptions): SchedulingResult {
 		const {
 			maxDeviation,

--- a/packages/core/src/metrics/fsrs-tools/scheduler/load-balance.service.ts
+++ b/packages/core/src/metrics/fsrs-tools/scheduler/load-balance.service.ts
@@ -294,8 +294,7 @@ export class LoadBalanceService {
 
 			const countWeight = (1 / count) ** 2.15;
 			const intervalWeight = (1 / offset) ** 3;
-			const weight =
-				countWeight * intervalWeight * (easyModifiers[i] ?? 1.0);
+			const weight = countWeight * intervalWeight * (easyModifiers[i] ?? 1.0);
 			return { day: offset, weight };
 		});
 

--- a/packages/core/src/metrics/fsrs-tools/scheduler/target-suggestion.ts
+++ b/packages/core/src/metrics/fsrs-tools/scheduler/target-suggestion.ts
@@ -1,0 +1,100 @@
+/**
+ * Target Suggestion
+ *
+ * Pure math behind the "conscious daily target": suggest a daily review
+ * target anchored in the user's demonstrated pace, and project when the
+ * backlog reaches zero at a given target.
+ */
+
+import { formatLocalDate } from "../../../utils";
+
+/** Active days required before pace statistics are trusted */
+export const MIN_ACTIVE_DAYS = 7;
+
+/** How far back demonstrated pace is measured */
+export const PACE_LOOKBACK_DAYS = 60;
+
+export interface PaceStats {
+	/** Median reviews completed on days with at least one review */
+	medianPace: number;
+	/** 75th percentile of reviews completed on active days */
+	p75Pace: number;
+	/** Days with at least one review in the lookback window */
+	activeDays: number;
+}
+
+export interface CatchUpProjection {
+	/** Days until the backlog reaches zero; null = never at this target */
+	days: number | null;
+	/** Local date (YYYY-MM-DD) when the backlog reaches zero; null = never */
+	date: string | null;
+}
+
+export function computePaceStats(dailyReviewCounts: number[]): PaceStats {
+	const active = dailyReviewCounts
+		.filter((count) => count > 0)
+		.sort((a, b) => a - b);
+	return {
+		medianPace: percentile(active, 0.5),
+		p75Pace: percentile(active, 0.75),
+		activeDays: active.length,
+	};
+}
+
+/**
+ * The pace below which the backlog grows by definition: upcoming dues per
+ * day, plus one when a backlog exists so it strictly shrinks.
+ */
+export function computeTargetFloor(
+	steadyStatePerDay: number,
+	backlogSize: number,
+): number {
+	return steadyStatePerDay + (backlogSize > 0 ? 1 : 0);
+}
+
+/**
+ * Suggested daily target: demonstrated median pace, floored at the water
+ * line. Null when pace history is too thin to trust (fewer than
+ * MIN_ACTIVE_DAYS active days) — callers fall back to the forecast average.
+ */
+export function computeSuggestedTarget(
+	pace: PaceStats,
+	steadyStatePerDay: number,
+	backlogSize: number,
+): number | null {
+	if (pace.activeDays < MIN_ACTIVE_DAYS) return null;
+	return Math.max(
+		pace.medianPace,
+		computeTargetFloor(steadyStatePerDay, backlogSize),
+	);
+}
+
+/**
+ * When the backlog hits zero at a given target: each day the target first
+ * covers that day's fresh dues (steady state) and only the surplus pays
+ * down the backlog.
+ */
+export function projectCatchUp(
+	targetPerDay: number,
+	steadyStatePerDay: number,
+	backlogSize: number,
+	from: Date,
+): CatchUpProjection {
+	if (backlogSize <= 0) return { days: 0, date: formatLocalDate(from) };
+	const surplus = targetPerDay - steadyStatePerDay;
+	if (surplus <= 0) return { days: null, date: null };
+	const days = Math.ceil(backlogSize / surplus);
+	const date = new Date(from);
+	date.setDate(date.getDate() + days);
+	return { days, date: formatLocalDate(date) };
+}
+
+/** Linear-interpolated percentile of an ascending sample; 0 when empty */
+function percentile(sortedAscending: number[], p: number): number {
+	if (sortedAscending.length === 0) return 0;
+	const rank = (sortedAscending.length - 1) * p;
+	const low = Math.floor(rank);
+	const lowValue = sortedAscending[low] ?? 0;
+	const highValue = sortedAscending[Math.ceil(rank)] ?? lowValue;
+	return Math.round(lowValue + (highValue - lowValue) * (rank - low));
+}

--- a/packages/core/src/metrics/fsrs-tools/statistics/workload-forecast.calculator.ts
+++ b/packages/core/src/metrics/fsrs-tools/statistics/workload-forecast.calculator.ts
@@ -149,7 +149,11 @@ export class WorkloadForecastCalculator {
 		maxDeviation: number = 20,
 		includeSourceUids?: ReadonlySet<string>,
 	): WorkloadForecastSummary {
-		const forecast = this.getForecast(days, excludeSourceUids, includeSourceUids);
+		const forecast = this.getForecast(
+			days,
+			excludeSourceUids,
+			includeSourceUids,
+		);
 
 		if (forecast.length === 0) {
 			return {
@@ -221,7 +225,11 @@ export class WorkloadForecastCalculator {
 		excludeSourceUids?: ReadonlySet<string>,
 		includeSourceUids?: ReadonlySet<string>,
 	): { day: number; dayName: string; avgCount: number }[] {
-		const forecast = this.getForecast(days, excludeSourceUids, includeSourceUids);
+		const forecast = this.getForecast(
+			days,
+			excludeSourceUids,
+			includeSourceUids,
+		);
 
 		// Group by day of week
 		const byDay = new Map<number, number[]>();

--- a/packages/core/src/types/settings.types.ts
+++ b/packages/core/src/types/settings.types.ts
@@ -290,7 +290,7 @@ export interface TrueRecallSettings {
 
 	/** Enable automatic load balancing when scheduling */
 	loadBalanceEnabled: boolean;
-	/** How the daily target is determined: computed from the forecast average or set manually */
+	/** How the daily target is determined: suggested from recent pace or set manually */
 	loadBalanceTargetMode: "auto" | "manual";
 	/** Target daily review count for load balancing (manual mode only) */
 	loadBalanceTarget: number;

--- a/packages/core/tests/services/fsrs-helper/fsrs-helper.service.test.ts
+++ b/packages/core/tests/services/fsrs-helper/fsrs-helper.service.test.ts
@@ -96,6 +96,87 @@ describe("FSRSHelperService", () => {
 		);
 		expect(preview.good.daysChanged).not.toBe(0);
 	});
+
+	describe("getWorkloadDecision", () => {
+		it("suggests the median pace in auto mode when history is rich", () => {
+			const store = createStore({
+				allCards: [],
+				balanceCards: [],
+				dailyReviews: Array.from({ length: 10 }, () => 120),
+			});
+			const helper = new FSRSHelperService(store as never, {
+				...DEFAULT_SETTINGS,
+				loadBalanceTargetMode: "auto",
+			});
+
+			const decision = helper.getWorkloadDecision();
+
+			expect(decision.suggestedTarget).toBe(120);
+			expect(decision.usedPaceFallback).toBe(false);
+			expect(helper.getEffectiveLoadBalanceTarget()).toBe(120);
+		});
+
+		it("falls back to the forecast average when pace history is thin", () => {
+			const cards = createCards("review", 62, State.Review, {
+				due: "2026-02-10T12:00:00.000Z",
+			});
+			const store = createStore({
+				allCards: cards,
+				balanceCards: cards,
+				dailyReviews: [100, 100],
+			});
+			const helper = new FSRSHelperService(store as never, {
+				...DEFAULT_SETTINGS,
+				loadBalanceTargetMode: "auto",
+			});
+
+			const decision = helper.getWorkloadDecision();
+
+			expect(decision.usedPaceFallback).toBe(true);
+			expect(decision.suggestedTarget).toBe(2);
+		});
+
+		it("keeps the manual target as the effective target", () => {
+			const store = createStore({
+				allCards: [],
+				balanceCards: [],
+				dailyReviews: Array.from({ length: 10 }, () => 120),
+			});
+			const helper = new FSRSHelperService(store as never, {
+				...DEFAULT_SETTINGS,
+				loadBalanceTargetMode: "manual",
+				loadBalanceTarget: 80,
+			});
+
+			const decision = helper.getWorkloadDecision();
+
+			expect(decision.effectiveTarget).toBe(80);
+			expect(decision.suggestedTarget).toBe(120);
+		});
+
+		it("projects backlog catch-up at the effective target", () => {
+			const overdue = createCards("overdue", 100, State.Review, {
+				due: "2026-01-15T12:00:00.000Z",
+			});
+			const store = createStore({
+				allCards: overdue,
+				balanceCards: overdue,
+				dailyReviews: Array.from({ length: 14 }, () => 50),
+			});
+			const helper = new FSRSHelperService(store as never, {
+				...DEFAULT_SETTINGS,
+				loadBalanceTargetMode: "auto",
+			});
+
+			const decision = helper.getWorkloadDecision();
+
+			// steady state bottoms out at 1 (computeAutoTarget's Math.max(1, ...))
+			expect(decision.backlogSize).toBe(100);
+			expect(decision.targetFloor).toBe(2);
+			expect(decision.suggestedTarget).toBe(50);
+			expect(decision.catchUp.days).toBe(Math.ceil(100 / 49));
+		});
+	});
 });
 
 interface TestCard {
@@ -136,9 +217,11 @@ function createCardsOnDate(
 function createStore({
 	allCards,
 	balanceCards,
+	dailyReviews = [],
 }: {
 	allCards: ReturnType<typeof createCards>;
 	balanceCards: ReturnType<typeof createCards>;
+	dailyReviews?: number[];
 }) {
 	return {
 		getCards: vi.fn(() => allCards),
@@ -158,6 +241,14 @@ function createStore({
 			},
 		),
 		updateCardDue: vi.fn(),
-		stats: { getDailyStats: vi.fn(() => null) },
+		stats: {
+			getDailyStats: vi.fn(() => null),
+			getDailyStatsFromReviewLog: vi.fn(() =>
+				dailyReviews.map((reviewsCompleted, index) => ({
+					date: `2025-12-${String(index + 1).padStart(2, "0")}`,
+					reviewsCompleted,
+				})),
+			),
+		},
 	};
 }

--- a/packages/core/tests/services/fsrs-helper/optimizer/parameter-optimizer.service.test.ts
+++ b/packages/core/tests/services/fsrs-helper/optimizer/parameter-optimizer.service.test.ts
@@ -7,20 +7,20 @@
  * was a loss in which only the decay parameter (w20) had a gradient.
  */
 import {
+	clipParameters,
 	default_w,
 	FSRSAlgorithm,
-	clipParameters,
 	generatorParameters,
 	Rating,
 	State,
 } from "ts-fsrs";
 import { describe, expect, it } from "vitest";
 
+import type { OptimizationReviewEntry } from "../../../../src/metrics/fsrs-tools/optimizer/optimizer.types";
 import {
 	isRecalled,
 	ParameterOptimizerService,
 } from "../../../../src/metrics/fsrs-tools/optimizer/parameter-optimizer.service";
-import type { OptimizationReviewEntry } from "../../../../src/metrics/fsrs-tools/optimizer/optimizer.types";
 import {
 	hashString,
 	mulberry32,

--- a/packages/core/tests/services/fsrs-helper/scheduler/load-balance.service.test.ts
+++ b/packages/core/tests/services/fsrs-helper/scheduler/load-balance.service.test.ts
@@ -640,4 +640,26 @@ describe("LoadBalanceService", () => {
 			});
 		});
 	});
+
+	describe("getBacklogSize", () => {
+		it("counts only cards due strictly before today", () => {
+			const cards = [
+				...createCardsOnDate("2026-01-20", 3),
+				...createCardsOnDate("2026-01-31", 2),
+				...createCardsOnDate("2026-02-01", 5),
+				...createCardsOnDate("2026-02-03", 4),
+			];
+			mockStore = createMockCardStore(cards);
+			service = new LoadBalanceService(mockStore);
+
+			expect(service.getBacklogSize()).toBe(5);
+		});
+
+		it("is zero without overdue cards", () => {
+			mockStore = createMockCardStore(createCardsOnDate("2026-02-02", 5));
+			service = new LoadBalanceService(mockStore);
+
+			expect(service.getBacklogSize()).toBe(0);
+		});
+	});
 });

--- a/packages/core/tests/services/fsrs-helper/scheduler/target-suggestion.test.ts
+++ b/packages/core/tests/services/fsrs-helper/scheduler/target-suggestion.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	computePaceStats,
+	computeSuggestedTarget,
+	computeTargetFloor,
+	MIN_ACTIVE_DAYS,
+	projectCatchUp,
+} from "../../../../src/metrics/fsrs-tools/scheduler/target-suggestion";
+
+describe("computePaceStats", () => {
+	it("ignores zero-review days and reports active day count", () => {
+		const stats = computePaceStats([0, 100, 0, 200, 300, 0]);
+
+		expect(stats.activeDays).toBe(3);
+		expect(stats.medianPace).toBe(200);
+	});
+
+	it("interpolates percentiles between samples", () => {
+		const stats = computePaceStats([100, 200, 300, 400]);
+
+		expect(stats.medianPace).toBe(250);
+		expect(stats.p75Pace).toBe(325);
+	});
+
+	it("returns zeros for an empty history", () => {
+		expect(computePaceStats([])).toEqual({
+			medianPace: 0,
+			p75Pace: 0,
+			activeDays: 0,
+		});
+	});
+});
+
+describe("computeTargetFloor", () => {
+	it.each([
+		["no backlog keeps the steady state", 50, 0, 50],
+		["a backlog raises the floor by one", 50, 10, 51],
+	])("%s", (_name, steadyState, backlog, expected) => {
+		expect(computeTargetFloor(steadyState, backlog)).toBe(expected);
+	});
+});
+
+describe("computeSuggestedTarget", () => {
+	const pace = (medianPace: number, activeDays: number) => ({
+		medianPace,
+		p75Pace: medianPace,
+		activeDays,
+	});
+
+	it("suggests the median pace when it clears the floor", () => {
+		expect(computeSuggestedTarget(pace(150, 30), 50, 100)).toBe(150);
+	});
+
+	it("raises to the floor when the median pace is under water", () => {
+		expect(computeSuggestedTarget(pace(40, 30), 50, 100)).toBe(51);
+	});
+
+	it("returns null when history is thinner than MIN_ACTIVE_DAYS", () => {
+		expect(
+			computeSuggestedTarget(pace(150, MIN_ACTIVE_DAYS - 1), 50, 100),
+		).toBe(null);
+	});
+});
+
+describe("projectCatchUp", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-02-01T10:00:00"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("divides the backlog by the surplus and rounds up", () => {
+		const projection = projectCatchUp(151, 47, 1000, new Date());
+
+		expect(projection.days).toBe(10);
+		expect(projection.date).toBe("2026-02-11");
+	});
+
+	it("never catches up when the target is at or below steady state", () => {
+		expect(projectCatchUp(47, 47, 1000, new Date())).toEqual({
+			days: null,
+			date: null,
+		});
+	});
+
+	it("is already caught up without a backlog", () => {
+		expect(projectCatchUp(100, 47, 0, new Date())).toEqual({
+			days: 0,
+			date: "2026-02-01",
+		});
+	});
+});

--- a/packages/obsidian/src/modals/study/ProjectForecastModal.tsx
+++ b/packages/obsidian/src/modals/study/ProjectForecastModal.tsx
@@ -30,8 +30,8 @@ function ProjectForecastBody({
 	return (
 		<>
 			<div class="ep:text-ui-small ep:text-obs-muted ep:mb-2">
-				Only this project's cards; the daily reference line is the project's
-				own 30-day average.
+				Only this project's cards; the daily reference line is the project's own
+				30-day average.
 			</div>
 			<WorkloadForecastSection
 				forecast={data.forecast}

--- a/packages/obsidian/src/settings/tabs/fsrs/LoadBalanceSection.tsx
+++ b/packages/obsidian/src/settings/tabs/fsrs/LoadBalanceSection.tsx
@@ -12,10 +12,9 @@ import {
 } from "@true-recall/obsidian/components";
 import { WorkloadForecastSection } from "@true-recall/obsidian/features/metrics/ui/stats/components/WorkloadForecastSection";
 
-import { describeSuggestion, sliderMax } from "./target-copy";
-import { TargetInsights } from "./TargetInsights";
-
 import type { FsrsPluginHost } from "../../../types/plugin-host.types";
+import { TargetInsights } from "./TargetInsights";
+import { describeSuggestion, sliderMax } from "./target-copy";
 import { useFsrsHelperOp } from "./useFsrsHelperOp";
 
 interface LoadBalanceSectionProps {

--- a/packages/obsidian/src/settings/tabs/fsrs/LoadBalanceSection.tsx
+++ b/packages/obsidian/src/settings/tabs/fsrs/LoadBalanceSection.tsx
@@ -8,10 +8,12 @@ import {
 	FormField,
 	SelectInput,
 	SliderInput,
-	TextInput,
 	ToggleInput,
 } from "@true-recall/obsidian/components";
 import { WorkloadForecastSection } from "@true-recall/obsidian/features/metrics/ui/stats/components/WorkloadForecastSection";
+
+import { describeSuggestion, sliderMax } from "./target-copy";
+import { TargetInsights } from "./TargetInsights";
 
 import type { FsrsPluginHost } from "../../../types/plugin-host.types";
 import { useFsrsHelperOp } from "./useFsrsHelperOp";
@@ -24,7 +26,7 @@ interface LoadBalanceSectionProps {
 
 const FORECAST_DAYS = 30;
 const TARGET_MODE_OPTIONS = [
-	{ value: "auto", label: "Automatic (forecast average)" },
+	{ value: "auto", label: "Automatic (suggested from your pace)" },
 	{ value: "manual", label: "Manual" },
 ];
 const BALANCE_RANGE_OPTIONS = [
@@ -82,7 +84,7 @@ export function LoadBalanceSection({
 			forecast: helper.getWorkloadForecast(FORECAST_DAYS),
 			summary: helper.getWorkloadForecastSummary(FORECAST_DAYS),
 			dayOfWeek: helper.getWorkloadByDayOfWeek(FORECAST_DAYS),
-			effectiveTarget: helper.getEffectiveLoadBalanceTarget(),
+			decision: helper.getWorkloadDecision(),
 		};
 	}, [
 		plugin.fsrsHelper,
@@ -123,7 +125,7 @@ export function LoadBalanceSection({
 				name="Daily target"
 				description={
 					settings.loadBalanceTargetMode === "auto" && forecastData
-						? `Automatic: ~${forecastData.effectiveTarget} reviews/day, the average of your upcoming workload (backlog included)`
+						? describeSuggestion(forecastData.decision)
 						: "How the daily review target is determined"
 				}
 			>
@@ -138,21 +140,28 @@ export function LoadBalanceSection({
 				/>
 			</FormField>
 
-			{settings.loadBalanceTargetMode === "manual" && (
+			{settings.loadBalanceTargetMode === "manual" && forecastData ? (
 				<FormField
 					name="Target daily reviews"
-					description="Target number of reviews per day for balancing"
+					description="Pick your number — the line below shows what it commits you to"
 				>
-					<TextInput
-						value={String(settings.loadBalanceTarget)}
-						onChange={(v) => {
-							const num = parseInt(v, 10) || 100;
-							void save({ loadBalanceTarget: Math.max(1, num) });
-						}}
-						placeholder="100"
+					<SliderInput
+						value={settings.loadBalanceTarget}
+						onChange={(v) => void save({ loadBalanceTarget: Math.max(1, v) })}
+						min={1}
+						max={sliderMax(forecastData.decision, settings.loadBalanceTarget)}
+						step={1}
+						formatTooltip={(v) => `${v}/day`}
 					/>
 				</FormField>
-			)}
+			) : null}
+
+			{forecastData ? (
+				<TargetInsights
+					decision={forecastData.decision}
+					target={forecastData.decision.effectiveTarget}
+				/>
+			) : null}
 
 			<FormField
 				name="Maximum deviation (%)"

--- a/packages/obsidian/src/settings/tabs/fsrs/TargetInsights.tsx
+++ b/packages/obsidian/src/settings/tabs/fsrs/TargetInsights.tsx
@@ -1,0 +1,38 @@
+import type { WorkloadDecision } from "@true-recall/core/metrics/fsrs-tools";
+
+import {
+	buildTargetReferences,
+	describeDrift,
+	describeTargetConsequence,
+} from "./target-copy";
+
+interface TargetInsightsProps {
+	decision: WorkloadDecision;
+	target: number;
+}
+
+/** Reference chips plus the live consequence line for a candidate target */
+export function TargetInsights({ decision, target }: TargetInsightsProps) {
+	const drift = describeDrift(decision, target);
+	return (
+		<div class="ep:flex ep:flex-col ep:gap-1.5 ep:py-2">
+			<div class="ep:flex ep:flex-wrap ep:gap-2">
+				{buildTargetReferences(decision).map((ref) => (
+					<span
+						key={ref.label}
+						class="ep:text-ui-smaller ep:text-obs-muted ep:rounded ep:border ep:border-obs-border ep:px-1.5 ep:py-0.5"
+						title={ref.hint}
+					>
+						{ref.label}: {ref.value}/day
+					</span>
+				))}
+			</div>
+			<span class="ep:text-ui-smaller ep:text-obs-muted">
+				{describeTargetConsequence(decision, target)}
+			</span>
+			{drift ? (
+				<span class="ep:text-ui-smaller ep:text-obs-warning">{drift}</span>
+			) : null}
+		</div>
+	);
+}

--- a/packages/obsidian/src/settings/tabs/fsrs/target-copy.ts
+++ b/packages/obsidian/src/settings/tabs/fsrs/target-copy.ts
@@ -1,0 +1,91 @@
+/**
+ * Copy and scale helpers for the daily-target picker. Pure functions so the
+ * wording and slider bounds are testable without rendering.
+ */
+
+import {
+	PACE_LOOKBACK_DAYS,
+	projectCatchUp,
+	type WorkloadDecision,
+} from "@true-recall/core/metrics/fsrs-tools";
+
+export interface TargetReference {
+	label: string;
+	value: number;
+	hint: string;
+}
+
+export function buildTargetReferences(
+	decision: WorkloadDecision,
+): TargetReference[] {
+	return [
+		{
+			label: "Floor",
+			value: decision.targetFloor,
+			hint: "Upcoming dues per day — below this the backlog grows",
+		},
+		{
+			label: "Your median",
+			value: decision.medianPace,
+			hint: `Typical pace on days you studied (last ${PACE_LOOKBACK_DAYS} days)`,
+		},
+		{
+			label: "Good days",
+			value: decision.p75Pace,
+			hint: "75th percentile of your active days",
+		},
+	];
+}
+
+export function describeTargetConsequence(
+	decision: WorkloadDecision,
+	target: number,
+): string {
+	if (decision.backlogSize === 0) {
+		return `No backlog — ${target}/day covers your upcoming ~${decision.steadyStatePerDay}/day of dues.`;
+	}
+	const catchUp = projectCatchUp(
+		target,
+		decision.steadyStatePerDay,
+		decision.backlogSize,
+		new Date(),
+	);
+	if (catchUp.days === null) {
+		return `Below your upcoming dues (~${decision.steadyStatePerDay}/day) — the ${decision.backlogSize}-card backlog will keep growing.`;
+	}
+	return `Backlog of ${decision.backlogSize} cards clears in ~${catchUp.days} days (${catchUp.date}).`;
+}
+
+export function describeSuggestion(decision: WorkloadDecision): string {
+	if (decision.usedPaceFallback) {
+		return `Suggested: ~${decision.suggestedTarget}/day — 30-day forecast average (not enough review history yet to measure your pace).`;
+	}
+	return `Suggested: ~${decision.suggestedTarget}/day — your median pace on active days, never below the ${decision.targetFloor}/day floor.`;
+}
+
+/** Nudge when the pinned target outruns demonstrated pace */
+export function describeDrift(
+	decision: WorkloadDecision,
+	target: number,
+): string | null {
+	if (decision.usedPaceFallback || decision.p75Pace === 0) return null;
+	if (target > decision.p75Pace) {
+		return `Heads up: ${target}/day is above your good-days pace (${decision.p75Pace}/day) — consider re-picking.`;
+	}
+	return null;
+}
+
+/** Slider ceiling: 1.5× the largest useful anchor, rounded up to tens */
+export function sliderMax(
+	decision: WorkloadDecision,
+	currentTarget: number,
+): number {
+	const anchor = Math.max(
+		50,
+		decision.suggestedTarget,
+		decision.p75Pace,
+		decision.targetFloor,
+		currentTarget,
+	);
+	return Math.ceil((anchor * 1.5) / 10) * 10;
+}

--- a/packages/obsidian/tests/settings/target-copy.test.ts
+++ b/packages/obsidian/tests/settings/target-copy.test.ts
@@ -1,5 +1,6 @@
-import type { WorkloadDecision } from "@true-recall/core/metrics/fsrs-tools";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WorkloadDecision } from "@true-recall/core/metrics/fsrs-tools";
 
 import {
 	buildTargetReferences,
@@ -95,9 +96,9 @@ describe("describeDrift", () => {
 	});
 
 	it("stays quiet without trustworthy pace history", () => {
-		expect(
-			describeDrift(createDecision({ usedPaceFallback: true }), 250),
-		).toBe(null);
+		expect(describeDrift(createDecision({ usedPaceFallback: true }), 250)).toBe(
+			null,
+		);
 	});
 });
 

--- a/packages/obsidian/tests/settings/target-copy.test.ts
+++ b/packages/obsidian/tests/settings/target-copy.test.ts
@@ -1,0 +1,121 @@
+import type { WorkloadDecision } from "@true-recall/core/metrics/fsrs-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	buildTargetReferences,
+	describeDrift,
+	describeSuggestion,
+	describeTargetConsequence,
+	sliderMax,
+} from "../../src/settings/tabs/fsrs/target-copy";
+
+function createDecision(
+	overrides: Partial<WorkloadDecision> = {},
+): WorkloadDecision {
+	return {
+		steadyStatePerDay: 47,
+		backlogSize: 1000,
+		targetFloor: 48,
+		medianPace: 140,
+		p75Pace: 190,
+		activeDays: 30,
+		suggestedTarget: 140,
+		usedPaceFallback: false,
+		catchUp: { days: 11, date: "2026-02-12" },
+		effectiveTarget: 140,
+		...overrides,
+	};
+}
+
+describe("describeTargetConsequence", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-02-01T10:00:00"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("shows the catch-up date when the target clears the backlog", () => {
+		const text = describeTargetConsequence(createDecision(), 147);
+
+		expect(text).toContain("1000");
+		expect(text).toContain("2026-02-11");
+	});
+
+	it("warns when the target is under water", () => {
+		const text = describeTargetConsequence(createDecision(), 40);
+
+		expect(text).toContain("keep growing");
+	});
+
+	it("reports a clear state without a backlog", () => {
+		const text = describeTargetConsequence(
+			createDecision({ backlogSize: 0 }),
+			100,
+		);
+
+		expect(text).toContain("No backlog");
+	});
+});
+
+describe("describeSuggestion", () => {
+	it("explains the pace anchor in the normal case", () => {
+		expect(describeSuggestion(createDecision())).toContain("median pace");
+	});
+
+	it("explains the fallback when history is thin", () => {
+		const text = describeSuggestion(
+			createDecision({ usedPaceFallback: true, suggestedTarget: 151 }),
+		);
+
+		expect(text).toContain("forecast average");
+		expect(text).toContain("151");
+	});
+});
+
+describe("buildTargetReferences", () => {
+	it("returns floor, median, and good-days chips in order", () => {
+		const refs = buildTargetReferences(createDecision());
+
+		expect(refs.map((r) => r.value)).toEqual([48, 140, 190]);
+	});
+});
+
+describe("describeDrift", () => {
+	it("nudges when the target exceeds the good-days pace", () => {
+		expect(describeDrift(createDecision(), 250)).toContain(
+			"above your good-days pace",
+		);
+	});
+
+	it("stays quiet at or below the good-days pace", () => {
+		expect(describeDrift(createDecision(), 190)).toBe(null);
+	});
+
+	it("stays quiet without trustworthy pace history", () => {
+		expect(
+			describeDrift(createDecision({ usedPaceFallback: true }), 250),
+		).toBe(null);
+	});
+});
+
+describe("sliderMax", () => {
+	it("scales past the largest anchor and rounds up to tens", () => {
+		expect(sliderMax(createDecision(), 100)).toBe(290);
+	});
+
+	it("never drops below 80 for tiny collections", () => {
+		const tiny = createDecision({
+			steadyStatePerDay: 1,
+			targetFloor: 1,
+			medianPace: 5,
+			p75Pace: 8,
+			suggestedTarget: 5,
+			backlogSize: 0,
+		});
+
+		expect(sliderMax(tiny, 10)).toBe(80);
+	});
+});


### PR DESCRIPTION
## Summary
- Auto target now suggests the user's demonstrated median pace (last 60 days of review history), floored at the steady-state dues/day so the backlog can only shrink; the old 30-day forecast average remains only as a thin-history fallback
- Settings show reference chips (floor / median / good days), a live consequence line (backlog clear date at the current target), and a drift nudge when a pinned target outruns demonstrated pace
- Manual mode picks the target with a slider scaled to the user's own numbers
- Balance now in auto mode uses the same suggestion instead of silently falling back to the legacy formula

## Test Plan
- [x] bun run test — full suite green (2277 tests on this branch)
- [x] bun run biome — only pre-existing styles.css findings remain
- [x] bun run build — typecheck + bundle green