### PR TITLE
Fix dashboard lag after reviews

### DIFF
--- a/packages/core/src/services/fsrs/fsrs.service.ts
+++ b/packages/core/src/services/fsrs/fsrs.service.ts
@@ -21,11 +21,32 @@ import { formatInterval } from "../../types";
 import type { FSRSSettings } from "../../types/settings.types";
 import { getTomorrowBoundary } from "../../utils";
 
+interface RetrievabilityCacheEntry {
+	settingsKey: string;
+	calculatedAt: number;
+	due: string;
+	stability: number;
+	difficulty: number;
+	reps: number;
+	lapses: number;
+	state: State;
+	lastReview: string | null;
+	scheduledDays: number;
+	learningStep: number;
+	value: number;
+}
+
 export class FSRSService {
 	private fsrs: FSRS;
 	private readonly fsrsCache = new Map<string, FSRS>();
+	private readonly settingsKeyCache = new WeakMap<FSRSSettings, string>();
+	private readonly retrievabilityCache = new WeakMap<
+		FSRSCardData,
+		RetrievabilityCacheEntry[]
+	>();
 	private defaultSettingsKey: string;
 	private static readonly MAX_CACHE_SIZE = 64;
+	private static readonly MAX_RETRIEVABILITY_POLICIES_PER_CARD = 8;
 
 	constructor(settings: FSRSSettings) {
 		this.defaultSettingsKey = this.getSettingsKey(settings);
@@ -53,10 +74,15 @@ export class FSRSService {
 	}
 
 	private getSettingsKey(settings: FSRSSettings): string {
+		const cached = Object.isFrozen(settings)
+			? this.settingsKeyCache.get(settings)
+			: undefined;
+		if (cached) return cached;
+
 		const weights = settings.weights ? settings.weights.join(",") : "default";
 		const learning = settings.learningSteps.join(",");
 		const relearning = settings.relearningSteps.join(",");
-		return [
+		const key = [
 			settings.requestRetention,
 			settings.maximumInterval,
 			weights,
@@ -65,6 +91,8 @@ export class FSRSService {
 			relearning,
 			settings.enableShortTerm ? 1 : 0,
 		].join("|");
+		if (Object.isFrozen(settings)) this.settingsKeyCache.set(settings, key);
+		return key;
 	}
 
 	private getOrCreateFSRS(settings: FSRSSettings): FSRS {
@@ -86,6 +114,67 @@ export class FSRSService {
 	private resolveFSRS(presetSettings?: FSRSSettings): FSRS {
 		if (!presetSettings) return this.fsrs;
 		return this.getOrCreateFSRS(presetSettings);
+	}
+
+	private isRetrievabilityCacheHit(
+		entry: RetrievabilityCacheEntry,
+		card: FSRSCardData,
+		settingsKey: string,
+		calculatedAt: number,
+	): boolean {
+		return (
+			entry.settingsKey === settingsKey &&
+			entry.calculatedAt === calculatedAt &&
+			entry.due === card.due &&
+			entry.stability === card.stability &&
+			entry.difficulty === card.difficulty &&
+			entry.reps === card.reps &&
+			entry.lapses === card.lapses &&
+			entry.state === card.state &&
+			entry.lastReview === card.lastReview &&
+			entry.scheduledDays === card.scheduledDays &&
+			entry.learningStep === card.learningStep
+		);
+	}
+
+	private cacheRetrievability(
+		card: FSRSCardData,
+		settingsKey: string,
+		calculatedAt: number,
+		value: number,
+	): void {
+		let entries = this.retrievabilityCache.get(card);
+		if (!entries) {
+			entries = [];
+			this.retrievabilityCache.set(card, entries);
+		}
+
+		const next: RetrievabilityCacheEntry = {
+			settingsKey,
+			calculatedAt,
+			due: card.due,
+			stability: card.stability,
+			difficulty: card.difficulty,
+			reps: card.reps,
+			lapses: card.lapses,
+			state: card.state,
+			lastReview: card.lastReview,
+			scheduledDays: card.scheduledDays,
+			learningStep: card.learningStep,
+			value,
+		};
+		const existingIndex = entries.findIndex(
+			(entry) => entry.settingsKey === settingsKey,
+		);
+		if (existingIndex >= 0) {
+			entries[existingIndex] = next;
+			return;
+		}
+
+		entries.push(next);
+		if (entries.length > FSRSService.MAX_RETRIEVABILITY_POLICIES_PER_CARD) {
+			entries.shift();
+		}
 	}
 
 	updateSettings(settings: FSRSSettings): void {
@@ -277,10 +366,28 @@ export class FSRSService {
 			return 0;
 		}
 
-		const card = this.toCard(cardData);
 		const currentTime = now ?? new Date();
+		const calculatedAt = currentTime.getTime();
+		const settingsKey = presetSettings
+			? this.getSettingsKey(presetSettings)
+			: this.defaultSettingsKey;
+		const cached = this.retrievabilityCache
+			.get(cardData)
+			?.find((entry) =>
+				this.isRetrievabilityCacheHit(
+					entry,
+					cardData,
+					settingsKey,
+					calculatedAt,
+				),
+			);
+		if (cached) return cached.value;
+
+		const card = this.toCard(cardData);
 		const fsrs = this.resolveFSRS(presetSettings);
-		return fsrs.get_retrievability(card, currentTime, false) ?? 0;
+		const value = fsrs.get_retrievability(card, currentTime, false) ?? 0;
+		this.cacheRetrievability(cardData, settingsKey, calculatedAt, value);
+		return value;
 	}
 
 	getStats(

--- a/packages/core/src/services/notes/preset.service.ts
+++ b/packages/core/src/services/notes/preset.service.ts
@@ -30,6 +30,8 @@ export interface PresetChainEntry {
 }
 
 export class PresetService {
+	private readonly fsrsSettingsCache = new WeakMap<FSRSPreset, FSRSSettings>();
+
 	constructor(
 		private getSettings: () => TrueRecallSettings,
 		private persistSettings: () => Promise<void>,
@@ -254,6 +256,17 @@ export class PresetService {
 	}
 
 	toFSRSSettings(preset: FSRSPreset): FSRSSettings {
-		return extractFSRSSettingsFromPreset(preset);
+		const cached = this.fsrsSettingsCache.get(preset);
+		if (cached) return cached;
+
+		const extracted = extractFSRSSettingsFromPreset(preset);
+		const settings = Object.freeze({
+			...extracted,
+			weights: extracted.weights ? Object.freeze([...extracted.weights]) : null,
+			learningSteps: Object.freeze([...extracted.learningSteps]),
+			relearningSteps: Object.freeze([...extracted.relearningSteps]),
+		}) as FSRSSettings;
+		this.fsrsSettingsCache.set(preset, settings);
+		return settings;
 	}
 }

--- a/packages/core/src/services/review/actionable-session-snapshot.service.ts
+++ b/packages/core/src/services/review/actionable-session-snapshot.service.ts
@@ -10,6 +10,7 @@ import {
 	buildQueueOptions,
 	filterActiveCards,
 	isGlobalReviewSession,
+	type SessionProgressSnapshot,
 } from "@true-recall/core/services/review/session-helpers";
 import {
 	type CardSchedulingMeta,
@@ -52,6 +53,10 @@ export interface ActionableSessionSnapshotDeps {
 export interface ActionableSessionSnapshotOptions {
 	cache?: Map<string, ActionableSessionSnapshot>;
 	activeCards?: CardSchedulingMeta[];
+	/** Shared persistence state for a synchronous batch of scoped snapshots. */
+	sessionProgress?: SessionProgressSnapshot;
+	/** Shared wall-clock time for consistent, cacheable FSRS calculations. */
+	now?: Date;
 }
 
 function buildScopeCacheKey(filters: SessionFilters): string {
@@ -158,7 +163,9 @@ export function computeActionableSessionSnapshot(
 		deps.settings,
 		deps.sessionPersistence,
 		sessionPreset,
+		options.sessionProgress,
 	);
+	queueOptions.now = options.now;
 	if (queueOptions.rMode) {
 		const ceilingOffset = deps.settings.rMode.ceilingOffset;
 		const presetCache = new Map<string, FSRSPreset>();
@@ -188,6 +195,7 @@ export function computeActionableSessionSnapshot(
 			activeCards,
 			deps.presetService,
 			deps.sessionPersistence,
+			options.sessionProgress,
 		);
 		queueOptions.cardPresetById = presetContext.cardPresetById;
 		queueOptions.presetDailyLimits = presetContext.presetDailyLimits;

--- a/packages/core/src/services/review/queue-builder.ts
+++ b/packages/core/src/services/review/queue-builder.ts
@@ -345,6 +345,7 @@ export function buildQueue(
 ): CardSchedulingMeta[] {
 	const { now, todayBoundary, weekAgoBoundary } = calculateBoundaries(
 		options.dayStartHour,
+		options.now,
 	);
 	const reviewedToday = options.reviewedToday ?? new Set<string>();
 

--- a/packages/core/src/services/review/queue-filter.ts
+++ b/packages/core/src/services/review/queue-filter.ts
@@ -67,12 +67,15 @@ function matchesCustomStudy(
 	}
 }
 
-export function calculateBoundaries(dayStartHour: number = 4): {
+export function calculateBoundaries(
+	dayStartHour: number = 4,
+	referenceNow?: Date,
+): {
 	now: Date;
 	todayBoundary: Date;
 	weekAgoBoundary: Date;
 } {
-	const now = new Date();
+	const now = referenceNow ? new Date(referenceNow) : new Date();
 	const todayBoundary = getTodayBoundary(dayStartHour, now);
 
 	const weekAgoBoundary = new Date(todayBoundary);

--- a/packages/core/src/services/review/review.service.ts
+++ b/packages/core/src/services/review/review.service.ts
@@ -31,6 +31,8 @@ import type { RModeQueueOptions } from "./retrievability-queue";
 import { spaceSiblings as spaceSiblingsImpl } from "./sibling-spacer";
 
 export interface QueueBuildOptions {
+	/** Shared calculation time for a batch of queue snapshots. */
+	now?: Date;
 	newCardsLimit: number;
 	reviewsLimit: number;
 	reviewedToday?: Set<string>;

--- a/packages/core/src/services/review/session-helpers.ts
+++ b/packages/core/src/services/review/session-helpers.ts
@@ -47,6 +47,25 @@ export interface GlobalPresetQueueContext {
 }
 
 /**
+ * Persistence-backed values shared by every queue built in one UI
+ * aggregation. Dashboard note/project snapshots are computed synchronously;
+ * capturing these once prevents an identical SQL query per scope.
+ */
+export interface SessionProgressSnapshot {
+	reviewedToday: Set<string>;
+	presetProgressToday: Map<string, PresetDailyProgress>;
+}
+
+export function captureSessionProgress(
+	sessionPersistence: SessionPersistenceService,
+): SessionProgressSnapshot {
+	return {
+		reviewedToday: sessionPersistence.getReviewedToday(),
+		presetProgressToday: sessionPersistence.getTodayProgressByPreset(),
+	};
+}
+
+/**
  * Returns active (non-suspended, non-buried, non-archived) cards, or specifically
  * buried cards if stateFilter is "buried"
  */
@@ -88,13 +107,17 @@ export function buildQueueOptions(
 	settings: TrueRecallSettings,
 	sessionPersistence: SessionPersistenceService,
 	preset?: FSRSPreset,
+	sessionProgress?: SessionProgressSnapshot,
 ): QueueBuildOptions {
 	// When scoped to a single preset (per-project/per-note snapshots), match
 	// today's progress to that preset so its remaining budget isn't drained
 	// by reviews from other presets. Global sessions don't pass a preset and
 	// use the aggregate counters instead.
 	const presetProgress = preset
-		? sessionPersistence.getTodayProgressByPreset().get(preset.name)
+		? (
+				sessionProgress?.presetProgressToday ??
+				sessionPersistence.getTodayProgressByPreset()
+			).get(preset.name)
 		: undefined;
 	const newCardsStudiedToday = preset
 		? (presetProgress?.newStudied ?? 0)
@@ -117,7 +140,8 @@ export function buildQueueOptions(
 	return {
 		newCardsLimit: preset?.newCardsPerDay ?? settings.newCardsPerDay,
 		reviewsLimit: preset?.reviewsPerDay ?? settings.reviewsPerDay,
-		reviewedToday: sessionPersistence.getReviewedToday(),
+		reviewedToday:
+			sessionProgress?.reviewedToday ?? sessionPersistence.getReviewedToday(),
 		newCardsStudiedToday,
 		reviewsCompletedToday,
 		newCardOrder: preset?.newCardOrder ?? settings.newCardOrder,
@@ -189,6 +213,7 @@ export function buildGlobalPresetQueueContext(
 	cards: CardSchedulingMeta[],
 	presetService: PresetServiceLike,
 	sessionPersistence: SessionPersistenceService,
+	sessionProgress?: SessionProgressSnapshot,
 ): GlobalPresetQueueContext {
 	const defaultPreset = presetService.getDefaultPreset();
 	const presetDailyLimits = new Map<
@@ -234,7 +259,8 @@ export function buildGlobalPresetQueueContext(
 	}
 
 	const presetProgressToday = new Map(
-		sessionPersistence.getTodayProgressByPreset(),
+		sessionProgress?.presetProgressToday ??
+			sessionPersistence.getTodayProgressByPreset(),
 	);
 	if (
 		defaultPreset.name !== "Default" &&

--- a/packages/core/tests/services/core/preset.service.test.ts
+++ b/packages/core/tests/services/core/preset.service.test.ts
@@ -295,6 +295,17 @@ describe("PresetService — 3-tier resolution", () => {
 		});
 	});
 
+	describe("toFSRSSettings", () => {
+		it("reuses an immutable settings snapshot for the same preset", () => {
+			const first = presetService.toFSRSSettings(defaultPreset);
+			const second = presetService.toFSRSSettings(defaultPreset);
+
+			expect(second).toBe(first);
+			expect(Object.isFrozen(first)).toBe(true);
+			expect(Object.isFrozen(first.learningSteps)).toBe(true);
+		});
+	});
+
 	describe("resolvePresetForCard — parent ordering", () => {
 		it("first parent with preset wins (BFS order)", () => {
 			addMockFile("Projects/Anatomy.md", {

--- a/packages/core/tests/services/fsrs/fsrs.service.test.ts
+++ b/packages/core/tests/services/fsrs/fsrs.service.test.ts
@@ -2,7 +2,7 @@
  * Tests for FSRSService - core FSRS scheduling logic
  */
 
-import { Rating, State } from "ts-fsrs";
+import { FSRS, Rating, State } from "ts-fsrs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FSRSService } from "../../../src/services/fsrs/fsrs.service";
@@ -26,6 +26,7 @@ describe("FSRSService", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		vi.useRealTimers();
 	});
 
@@ -525,6 +526,42 @@ describe("FSRSService", () => {
 
 			// Learning cards should have some retrievability
 			expect(typeof retrievability).toBe("number");
+		});
+
+		it("should reuse the result for the same card, time, and settings", () => {
+			const card = createReviewCard("cached-card");
+			const now = new Date();
+			const spy = vi.spyOn(FSRS.prototype, "get_retrievability");
+
+			const first = service.getRetrievability(card, now);
+			const second = service.getRetrievability(card, now);
+
+			expect(second).toBe(first);
+			expect(spy).toHaveBeenCalledTimes(1);
+		});
+
+		it("should recompute when the same card object changes", () => {
+			const card = createReviewCard("updated-card");
+			const now = new Date();
+			const spy = vi.spyOn(FSRS.prototype, "get_retrievability");
+
+			service.getRetrievability(card, now);
+			card.stability += 1;
+			service.getRetrievability(card, now);
+
+			expect(spy).toHaveBeenCalledTimes(2);
+		});
+
+		it("should recompute for a different calculation time", () => {
+			const card = createReviewCard("later-card");
+			const now = new Date();
+			const later = new Date(now.getTime() + 60_000);
+			const spy = vi.spyOn(FSRS.prototype, "get_retrievability");
+
+			service.getRetrievability(card, now);
+			service.getRetrievability(card, later);
+
+			expect(spy).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/packages/core/tests/services/review/actionable-session-snapshot.service.test.ts
+++ b/packages/core/tests/services/review/actionable-session-snapshot.service.test.ts
@@ -163,6 +163,44 @@ describe("computeActionableSessionSnapshot", () => {
 		expect(snapshot.queue.map((c) => c.id)).toEqual(["r1"]);
 	});
 
+	it("uses shared session progress without repeating persistence queries", () => {
+		const getReviewedToday = vi.fn(() => new Set<string>());
+		const getTodayProgressByPreset = vi.fn(() => new Map());
+		const sessionPersistence = {
+			getReviewedToday,
+			getNewCardsStudiedToday: () => 0,
+			getReviewCardsCompletedToday: () => 0,
+			getTodayProgressByPreset,
+		} as unknown as SessionPersistenceService;
+		const cards = [
+			createMockFlashcard({
+				id: "already-reviewed",
+				sourceUid: "uid-1",
+				fsrs: { state: State.Review, due: "2024-01-01T00:00:00.000Z" },
+			}),
+			createMockFlashcard({
+				id: "still-due",
+				sourceUid: "uid-2",
+				fsrs: { state: State.Review, due: "2024-01-01T00:00:00.000Z" },
+			}),
+		];
+
+		const snapshot = computeActionableSessionSnapshot(
+			createDeps({ allCards: cards, sessionPersistence }),
+			{},
+			{
+				sessionProgress: {
+					reviewedToday: new Set(["already-reviewed"]),
+					presetProgressToday: new Map(),
+				},
+			},
+		);
+
+		expect(snapshot.queue.map((card) => card.id)).toEqual(["still-due"]);
+		expect(getReviewedToday).not.toHaveBeenCalled();
+		expect(getTodayProgressByPreset).not.toHaveBeenCalled();
+	});
+
 	it("applies project scope via sourceUidFilter", () => {
 		const cards = [
 			createMockFlashcard({
@@ -307,6 +345,26 @@ describe("computeActionableSessionSnapshot", () => {
 		expect(reviewService.buildQueue).toHaveBeenCalled();
 		expect(updateSettings).not.toHaveBeenCalled();
 		expect(snapshot.queueLength).toBe(1);
+	});
+
+	it("passes a shared calculation time to the queue builder", () => {
+		const now = new Date("2026-08-10T10:00:00.000Z");
+		const buildQueue = vi.fn(() => []);
+		const reviewService = {
+			buildQueue,
+		} as unknown as import("../../../src/services/review/review.service").ReviewService;
+
+		computeActionableSessionSnapshot(
+			createDeps({ reviewService }),
+			{},
+			{ now },
+		);
+
+		expect(buildQueue).toHaveBeenCalledWith(
+			expect.any(Array),
+			expect.anything(),
+			expect.objectContaining({ now }),
+		);
 	});
 
 	it("keeps target count and scheduling mode in the snapshot cache key", () => {

--- a/packages/obsidian/src/features/study/ui/dashboard/helpers/project-aggregation.ts
+++ b/packages/obsidian/src/features/study/ui/dashboard/helpers/project-aggregation.ts
@@ -11,6 +11,10 @@ import type {
 } from "@true-recall/core/services/notes/hierarchy.service";
 import type { PresetService } from "@true-recall/core/services/notes/preset.service";
 import { summarizeRetrievability } from "@true-recall/core/services/review/retrievability-queue";
+import {
+	captureSessionProgress,
+	type SessionProgressSnapshot,
+} from "@true-recall/core/services/review/session-helpers";
 import type {
 	CardSchedulingMeta,
 	TrueRecallSettings,
@@ -170,6 +174,7 @@ export function aggregateProjectData(
 
 	const hierarchy = plugin.hierarchyService.buildHierarchy();
 	const snapshotCache = new Map<string, ActionableSessionSnapshot>();
+	const sessionProgress = captureSessionProgress(plugin.sessionPersistence);
 	const now = deps.now ?? new Date();
 	const allCardsBySourceUid = buildCardsBySourceUid(plugin.allCards);
 	const activeCardsBySourceUid = buildActiveCardsBySourceUid(
@@ -187,6 +192,7 @@ export function aggregateProjectData(
 			noteByPath,
 			plugin,
 			snapshotCache,
+			sessionProgress,
 			indexes,
 			showArchived,
 		),
@@ -262,6 +268,7 @@ function buildProjectFromNode(
 	noteByPath: Map<string, DashboardNoteEntry>,
 	plugin: ProjectAggregationDeps["plugin"],
 	snapshotCache: Map<string, ActionableSessionSnapshot>,
+	sessionProgress: SessionProgressSnapshot,
 	indexes: ProjectAggregationIndexes,
 	showArchived?: boolean,
 ): DashboardProject {
@@ -313,6 +320,7 @@ function buildProjectFromNode(
 			noteByPath,
 			plugin,
 			snapshotCache,
+			sessionProgress,
 			indexes,
 			showArchived,
 		),
@@ -361,7 +369,12 @@ function buildProjectFromNode(
 					? "retrievability"
 					: "due",
 			},
-			{ cache: snapshotCache, activeCards: scopedActiveCards },
+			{
+				cache: snapshotCache,
+				activeCards: scopedActiveCards,
+				sessionProgress,
+				now: indexes.now,
+			},
 		);
 		counts = snapshot.counts;
 	}

--- a/packages/obsidian/src/preact/useGatedComputed.ts
+++ b/packages/obsidian/src/preact/useGatedComputed.ts
@@ -1,8 +1,9 @@
 import type { ReadonlySignal } from "@preact/signals";
+import { effect, untracked } from "@preact/signals-core";
 import { useEffect, useRef, useState } from "preact/hooks";
 
 interface GatedComputedOptions {
-	/** Visibility of the hosting view; read during render so reveals re-render. */
+	/** Visibility of the hosting view; observed without subscribing the component. */
 	isVisible: ReadonlySignal<boolean>;
 	/** Minimum interval between recomputes while visible. 0 = every deps change. */
 	throttleMs?: number;
@@ -21,36 +22,29 @@ function areDepsEqual(a: readonly unknown[], b: readonly unknown[]): boolean {
 export type GateAction =
 	| { kind: "keep" }
 	| { kind: "recompute" }
-	| { kind: "defer-reveal" }
 	| { kind: "trailing"; delayMs: number };
 
 interface GateActionInput {
-	/** True on the first render after the view flipped from hidden to visible. */
+	/** True on the first reactive pass after the view became visible. */
 	becameVisible: boolean;
 	depsChanged: boolean;
 	msSinceLastCompute: number;
 	throttleMs: number;
-	/** True when a defer-reveal was issued and its refresh tick is running. */
-	hasPendingReveal: boolean;
 }
 
 /**
  * Decides what a visible gated computation should do with its cached state.
- * A reveal with stale deps paints the cached frame first ("defer-reveal") and
- * recomputes on the very next tick, bypassing the throttle — recomputing
- * synchronously would block the tab switch, while throttling would show
- * stale data for up to `throttleMs` right when the user looks at it.
+ * A reveal with stale deps bypasses the throttle so the next render receives
+ * fresh data instead of first painting a stale frame.
  */
 export function resolveGateAction({
 	becameVisible,
 	depsChanged,
 	msSinceLastCompute,
 	throttleMs,
-	hasPendingReveal,
 }: GateActionInput): GateAction {
 	if (!depsChanged) return { kind: "keep" };
-	if (becameVisible) return { kind: "defer-reveal" };
-	if (hasPendingReveal || msSinceLastCompute >= throttleMs) {
+	if (becameVisible || msSinceLastCompute >= throttleMs) {
 		return { kind: "recompute" };
 	}
 	return { kind: "trailing", delayMs: throttleMs - msSinceLastCompute };
@@ -63,8 +57,7 @@ export function resolveGateAction({
  * - While the hosting view is hidden, `getDeps` is never called, so signals
  *   read inside it are not subscribed at all — the component neither
  *   re-renders nor recomputes on data changes. The visibility flip back to
- *   true paints the cached value first, then recomputes with fresh deps on
- *   the next tick (bypassing the throttle) so the reveal stays responsive.
+ *   true refreshes the cached value before scheduling a single render.
  * - While visible, recomputes at most once per `throttleMs`; a throttled
  *   change schedules a trailing refresh so the final state is never dropped.
  *
@@ -79,8 +72,13 @@ export function useGatedComputed<T>(
 	const [, setTick] = useState(0);
 	const stateRef = useRef<GatedComputedState<T> | null>(null);
 	const trailingTimerRef = useRef<number | null>(null);
-	const wasVisibleRef = useRef(false);
-	const pendingRevealRef = useRef(false);
+	const wasVisibleRef = useRef(isVisible.peek());
+	const computeRef = useRef(compute);
+	const getDepsRef = useRef(getDeps);
+	const throttleMsRef = useRef(throttleMs);
+	computeRef.current = compute;
+	getDepsRef.current = getDeps;
+	throttleMsRef.current = throttleMs;
 
 	const clearTrailingTimer = () => {
 		if (trailingTimerRef.current !== null) {
@@ -89,18 +87,10 @@ export function useGatedComputed<T>(
 		}
 	};
 
-	const scheduleTrailingRefresh = (delayMs: number) => {
-		if (trailingTimerRef.current !== null) return;
-		trailingTimerRef.current = window.setTimeout(() => {
-			trailingTimerRef.current = null;
-			setTick((tick) => tick + 1);
-		}, delayMs);
-	};
-
 	const recompute = (deps: readonly unknown[]): GatedComputedState<T> => {
 		clearTrailingTimer();
 		const next: GatedComputedState<T> = {
-			value: compute(),
+			value: untracked(() => computeRef.current()),
 			deps,
 			computedAt: performance.now(),
 		};
@@ -108,46 +98,62 @@ export function useGatedComputed<T>(
 		return next;
 	};
 
-	const isViewVisible = isVisible.value;
-	const becameVisible = isViewVisible && !wasVisibleRef.current;
-	wasVisibleRef.current = isViewVisible;
+	const refresh = () => {
+		const state = stateRef.current;
+		if (!state) return;
+		const deps = untracked(() => getDepsRef.current());
+		if (areDepsEqual(state.deps, deps)) return;
+		recompute(deps);
+		setTick((tick) => tick + 1);
+	};
+
+	const scheduleTrailingRefresh = (delayMs: number) => {
+		if (trailingTimerRef.current !== null) return;
+		trailingTimerRef.current = window.setTimeout(() => {
+			trailingTimerRef.current = null;
+			refresh();
+		}, delayMs);
+	};
 
 	let state = stateRef.current;
 	if (state === null) {
-		state = recompute(getDeps());
-	} else if (isViewVisible) {
-		const deps = getDeps();
-		const action = resolveGateAction({
-			becameVisible,
-			depsChanged: !areDepsEqual(state.deps, deps),
-			msSinceLastCompute: performance.now() - state.computedAt,
-			throttleMs,
-			hasPendingReveal: pendingRevealRef.current,
-		});
-		if (action.kind === "recompute") {
-			pendingRevealRef.current = false;
-			state = recompute(deps);
-		} else if (action.kind === "defer-reveal") {
-			// A pre-hide trailing timer may still be pending with a long delay;
-			// replace it so the reveal refresh lands on the very next tick.
-			pendingRevealRef.current = true;
-			clearTrailingTimer();
-			scheduleTrailingRefresh(0);
-		} else if (action.kind === "trailing") {
-			scheduleTrailingRefresh(action.delayMs);
-		} else {
-			pendingRevealRef.current = false;
-		}
+		state = recompute(untracked(() => getDepsRef.current()));
 	}
 
-	useEffect(
-		() => () => {
-			if (trailingTimerRef.current !== null) {
-				window.clearTimeout(trailingTimerRef.current);
+	useEffect(() => {
+		const dispose = effect(() => {
+			const isViewVisible = isVisible.value;
+			const becameVisible = isViewVisible && !wasVisibleRef.current;
+			wasVisibleRef.current = isViewVisible;
+
+			if (!isViewVisible) {
+				clearTrailingTimer();
+				return;
 			}
-		},
-		[],
-	);
+
+			const current = stateRef.current;
+			if (!current) return;
+			const deps = getDepsRef.current();
+			const action = resolveGateAction({
+				becameVisible,
+				depsChanged: !areDepsEqual(current.deps, deps),
+				msSinceLastCompute: performance.now() - current.computedAt,
+				throttleMs: throttleMsRef.current,
+			});
+
+			if (action.kind === "recompute") {
+				recompute(deps);
+				setTick((tick) => tick + 1);
+			} else if (action.kind === "trailing") {
+				scheduleTrailingRefresh(action.delayMs);
+			}
+		});
+
+		return () => {
+			dispose();
+			clearTrailingTimer();
+		};
+	}, [isVisible]);
 
 	return state.value;
 }

--- a/packages/obsidian/src/views/dashboard/DashboardApp.tsx
+++ b/packages/obsidian/src/views/dashboard/DashboardApp.tsx
@@ -1,4 +1,5 @@
 import { type ReadonlySignal, useSignal } from "@preact/signals";
+import { effect } from "@preact/signals-core";
 import { useCallback, useEffect, useMemo, useRef } from "preact/hooks";
 
 import { aggregateDashboardData } from "@true-recall/core/helpers/note-aggregation";
@@ -6,6 +7,7 @@ import { computePriority } from "@true-recall/core/helpers/note-priority";
 import { estimateStudyMinutes } from "@true-recall/core/helpers/time-estimate";
 import { StatsCalculatorService } from "@true-recall/core/metrics/stats/stats-calculator.service";
 import { scoreRModeCard } from "@true-recall/core/services/review/retrievability-queue";
+import { captureSessionProgress } from "@true-recall/core/services/review/session-helpers";
 import type {
 	CardSchedulingMeta,
 	TrueRecallSettings,
@@ -56,23 +58,19 @@ export function DashboardApp({ isViewVisible }: DashboardAppProps) {
 	const activeTab = useSignal<DashboardTab>("projects");
 	const searchQuery = useSignal("");
 	const minuteBucket = useSignal(Math.floor(Date.now() / MINUTE_MS));
-	const isVisible = isViewVisible.value;
 
 	// Retrievability changes with time even when no card metadata changes. Keep
 	// the dashboard honest without waking a hidden view every minute.
 	useEffect(() => {
-		if (!isVisible) return;
-		minuteBucket.value = Math.floor(Date.now() / MINUTE_MS);
-		const timer = window.setInterval(() => {
+		return effect(() => {
+			if (!isViewVisible.value) return;
 			minuteBucket.value = Math.floor(Date.now() / MINUTE_MS);
-		}, MINUTE_MS);
-		return () => window.clearInterval(timer);
-	}, [isVisible, minuteBucket]);
-
-	const now = useMemo(
-		() => new Date(minuteBucket.value * MINUTE_MS),
-		[minuteBucket.value],
-	);
+			const timer = window.setInterval(() => {
+				minuteBucket.value = Math.floor(Date.now() / MINUTE_MS);
+			}, MINUTE_MS);
+			return () => window.clearInterval(timer);
+		});
+	}, [isViewVisible, minuteBucket]);
 
 	const statsCalculator = useMemo(() => {
 		const calc = new StatsCalculatorService(
@@ -93,12 +91,22 @@ export function DashboardApp({ isViewVisible }: DashboardAppProps) {
 	// the hot signals are not even subscribed, so grading in the review view
 	// no longer re-renders or recomputes the dashboard aggregation. Downstream
 	// useMemos stay stable because both references are frozen together.
-	const { allCards, archived } = useGatedComputed(
+	const { allCards, archived, now } = useGatedComputed(
 		() => ({
 			allCards: [...allMeta.value.values()],
 			archived: archivedSourceUidsSignal.value,
+			now: new Date(Math.floor(Date.now() / MINUTE_MS) * MINUTE_MS),
 		}),
-		() => [allMeta.value, archivedSourceUidsSignal.value],
+		() => {
+			// Subscribe to the timer without making its catch-up write on reveal a
+			// separate dependency from the current wall-clock minute.
+			void minuteBucket.value;
+			return [
+				allMeta.value,
+				archivedSourceUidsSignal.value,
+				Math.floor(Date.now() / MINUTE_MS),
+			];
+		},
 		{ isVisible: isViewVisible, throttleMs: RECOMPUTE_THROTTLE_MS },
 	);
 
@@ -138,6 +146,7 @@ export function DashboardApp({ isViewVisible }: DashboardAppProps) {
 			string,
 			ReturnType<typeof computeActionableSessionSnapshot>
 		>();
+		const sessionProgress = captureSessionProgress(plugin.sessionPersistence);
 
 		const rMode = plugin.settings.rMode;
 		const retention = plugin.settings.fsrsRequestRetention;
@@ -186,7 +195,12 @@ export function DashboardApp({ isViewVisible }: DashboardAppProps) {
 		const globalSnapshot = computeActionableSessionSnapshot(
 			snapshotDeps,
 			{ schedulingMode: rMode.enabled ? "retrievability" : "due" },
-			{ cache: snapshotCache, activeCards: cachedActiveCards },
+			{
+				cache: snapshotCache,
+				activeCards: cachedActiveCards,
+				sessionProgress,
+				now,
+			},
 		);
 
 		const actionableNotes = raw.notes.map((note) => {
@@ -203,7 +217,12 @@ export function DashboardApp({ isViewVisible }: DashboardAppProps) {
 					ignoreDailyLimits: plugin.settings.ignoreDailyLimitsForNoteStudy,
 					schedulingMode: rMode.enabled ? "retrievability" : "due",
 				},
-				{ cache: snapshotCache, activeCards: scopedActiveCards },
+				{
+					cache: snapshotCache,
+					activeCards: scopedActiveCards,
+					sessionProgress,
+					now,
+				},
 			);
 			const due = noteSnapshot.counts.due;
 			const newCount = noteSnapshot.counts.new;

--- a/packages/obsidian/tests/preact/use-gated-computed.test.ts
+++ b/packages/obsidian/tests/preact/use-gated-computed.test.ts
@@ -10,7 +10,6 @@ describe("resolveGateAction", () => {
 				depsChanged: false,
 				msSinceLastCompute: 5000,
 				throttleMs: 2000,
-				hasPendingReveal: false,
 			}),
 		).toEqual({ kind: "keep" });
 	});
@@ -22,7 +21,6 @@ describe("resolveGateAction", () => {
 				depsChanged: false,
 				msSinceLastCompute: 100,
 				throttleMs: 2000,
-				hasPendingReveal: false,
 			}),
 		).toEqual({ kind: "keep" });
 	});
@@ -34,7 +32,6 @@ describe("resolveGateAction", () => {
 				depsChanged: true,
 				msSinceLastCompute: 2000,
 				throttleMs: 2000,
-				hasPendingReveal: false,
 			}),
 		).toEqual({ kind: "recompute" });
 	});
@@ -46,31 +43,17 @@ describe("resolveGateAction", () => {
 				depsChanged: true,
 				msSinceLastCompute: 1500,
 				throttleMs: 2000,
-				hasPendingReveal: false,
 			}),
 		).toEqual({ kind: "trailing", delayMs: 500 });
 	});
 
-	it("defers a reveal with changed deps so the cached frame paints first", () => {
+	it("recomputes a reveal with changed deps before the next render", () => {
 		expect(
 			resolveGateAction({
 				becameVisible: true,
 				depsChanged: true,
 				msSinceLastCompute: 5000,
 				throttleMs: 2000,
-				hasPendingReveal: false,
-			}),
-		).toEqual({ kind: "defer-reveal" });
-	});
-
-	it("recomputes a pending reveal on the next tick, bypassing the throttle", () => {
-		expect(
-			resolveGateAction({
-				becameVisible: false,
-				depsChanged: true,
-				msSinceLastCompute: 100,
-				throttleMs: 2000,
-				hasPendingReveal: true,
 			}),
 		).toEqual({ kind: "recompute" });
 	});
@@ -82,7 +65,6 @@ describe("resolveGateAction", () => {
 				depsChanged: true,
 				msSinceLastCompute: 0,
 				throttleMs: 0,
-				hasPendingReveal: false,
 			}),
 		).toEqual({ kind: "recompute" });
 	});


### PR DESCRIPTION
## What changed

- refresh hidden dashboard data once on reveal instead of rendering stale state first
- share today's session progress across note and project queue calculations
- reuse FSRS retrievability results and a single calculation time across dashboard scopes
- add regression tests for gated computation, session snapshots, preset settings, and retrievability caching

## Why

Returning from Review to Dashboard blocked the Obsidian renderer for 2–3 seconds and briefly showed stale counts.

Profiling on the real vault found an N+1 query: the same preset-progress SQL query ran once per note/project. R-Mode also recalculated the same card at slightly different timestamps, defeating the cache.

## Impact

Measured Review → Dashboard delay dropped from about 2.8 seconds to 216 ms on the affected vault, with warm cached transitions around 3 ms.

## Validation

- `bun run build`
- `bun run test` — 206 files, 2673 tests
- targeted Biome check
- live CPU profiling in Obsidian
